### PR TITLE
fix: wrap Typer app in main() for Windows pipx compatibility

### DIFF
--- a/packages/aps-cli-node/package.json
+++ b/packages/aps-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates.",
   "type": "module",
   "bin": {

--- a/packages/aps-cli-py/pyproject.toml
+++ b/packages/aps-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agnostic-prompt-aps"
-version = "1.1.1"
+version = "1.1.2"
 description = "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,7 +25,7 @@ dev = [
 ]
 
 [project.scripts]
-aps = "aps_cli.cli:app"
+aps = "aps_cli.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/chris-buckley/agnostic-prompt-standard"

--- a/packages/aps-cli-py/src/aps_cli/__init__.py
+++ b/packages/aps-cli-py/src/aps_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/packages/aps-cli-py/src/aps_cli/cli.py
+++ b/packages/aps-cli-py/src/aps_cli/cli.py
@@ -246,5 +246,10 @@ def version():
     console.print(__version__)
 
 
-if __name__ == "__main__":
+def main():
+    """Entry point for the CLI."""
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   authors: "Christopher Buckley; Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
-  framework_revision: "1.1.1"
+  framework_revision: "1.1.2"
   last_updated: "2026-01-15"
 ---
 


### PR DESCRIPTION
## Summary
- Wraps Typer `app` object in a `main()` function for Windows pipx compatibility
- Updates entry point in `pyproject.toml` from `:app` to `:main`
- Bumps version to 1.1.2 across all version files

## Problem
`pipx run agnostic-prompt-aps` fails on Windows with:
```
FileNotFoundError: [WinError 2] The system cannot find the file specified
NOTE: running app 'aps.exe' from 'agnostic-prompt-aps'
```

## Root Cause
The entry point pointed directly to the Typer `app` object. While Typer objects are callable, some environments (particularly pipx on Windows) expect a regular function as the entry point.

## Test plan
- [x] Version check passes (`python tools/check_versions.py`)
- [x] Python CLI tests pass (`pytest -q tests`)
- [x] Node CLI tests pass (`node --test`)
- [x] CLI commands work (`aps doctor`, `aps --help`)
- [ ] After publishing, verify `pipx run agnostic-prompt-aps doctor` works on Windows