### PR TITLE
ci: auto-publish packages on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   push:
+    branches: [main]
     tags:
       - 'v*.*.*'
 
@@ -9,21 +10,73 @@ permissions:
   contents: write
   id-token: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
+  check_release:
+    # Only run on push to main (not on tag push)
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check if release needed
+        id: check
+        run: |
+          # Extract version from SKILL.md
+          VERSION=$(python -c "
+          import re
+          text = open('skill/agnostic-prompt-standard/SKILL.md').read()
+          m = re.search(r'framework_revision:\s*\"?([0-9]+\.[0-9]+\.[0-9]+)\"?', text)
+          print(m.group(1))
+          ")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Check if tag exists
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists, skipping release"
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          else
+            echo "Tag v$VERSION does not exist, will release"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          fi
+
   verify:
+    needs: check_release
+    if: |
+      always() &&
+      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Version consistency (tag must match)
-        run: python tools/check_versions.py --tag "${{ github.ref_name }}"
+      - name: Version consistency
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            python tools/check_versions.py --tag "${{ github.ref_name }}"
+          else
+            python tools/check_versions.py
+          fi
       - name: Skill link integrity
         run: python tools/check_skill_links.py
 
   publish_node:
-    needs: verify
+    needs: [check_release, verify]
+    if: |
+      always() &&
+      needs.verify.result == 'success' &&
+      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -51,7 +104,11 @@ jobs:
         run: npm publish --access public
 
   publish_python:
-    needs: verify
+    needs: [check_release, verify]
+    if: |
+      always() &&
+      needs.verify.result == 'success' &&
+      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     env:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
@@ -77,8 +134,36 @@ jobs:
         with:
           packages-dir: packages/aps-cli-py/dist
 
+  create_tag_and_release:
+    needs: [check_release, publish_node, publish_python]
+    if: needs.check_release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ needs.check_release.outputs.version }}"
+          git push origin "v${{ needs.check_release.outputs.version }}"
+      - name: Create skill zip
+        run: |
+          mkdir -p dist
+          cd skill
+          zip -r "../dist/agnostic-prompt-standard-skill-v${{ needs.check_release.outputs.version }}.zip" agnostic-prompt-standard
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.check_release.outputs.version }}
+          files: dist/agnostic-prompt-standard-skill-v${{ needs.check_release.outputs.version }}.zip
+          generate_release_notes: true
+
   github_release:
+    # Only for manual tag-based releases
     needs: [publish_node, publish_python]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Automatically publish to npm and PyPI when code is merged to main and the version has changed
- Uses git tags as source of truth for published versions
- Creates tag and GitHub release after successful publish
- Preserves manual tag-based workflow as fallback

## How it works
1. On push to main: extract version from `SKILL.md`, check if tag `v{version}` exists
2. If tag doesn't exist → run verification, publish to npm/PyPI, create tag and release
3. Manual tag pushes (`v*.*.*`) still trigger the existing release flow

## Changes
- Add `branches: [main]` trigger
- Add `check_release` job to detect version changes
- Add `create_tag_and_release` job for auto-releases
- Add `concurrency` group to prevent race conditions
- Modify existing jobs with conditional logic to support both flows

## Test plan
- [ ] Merge PR with unchanged version → workflow runs but skips publish (tag exists)
- [ ] Merge PR with bumped version → publishes and creates tag/release
- [ ] Manual tag push → existing workflow still functions