### PR TITLE
fix: add __main__.py for pipx Windows compatibility

### DIFF
--- a/packages/aps-cli-node/package.json
+++ b/packages/aps-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates.",
   "type": "module",
   "bin": {

--- a/packages/aps-cli-py/pyproject.toml
+++ b/packages/aps-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agnostic-prompt-aps"
-version = "1.1.2"
+version = "1.1.3"
 description = "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/aps-cli-py/src/aps_cli/__init__.py
+++ b/packages/aps-cli-py/src/aps_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/packages/aps-cli-py/src/aps_cli/__main__.py
+++ b/packages/aps-cli-py/src/aps_cli/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running the package with `python -m aps_cli`."""
+from aps_cli.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 metadata:
   authors: "Christopher Buckley; Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
-  framework_revision: "1.1.2"
+  framework_revision: "1.1.3"
   last_updated: "2026-01-15"
 ---
 


### PR DESCRIPTION
## Summary
- Add `__main__.py` to enable `python -m aps_cli` invocation
- Fixes `pipx run agnostic-prompt-aps` failing on Windows with `FileNotFoundError`
- Bump version to 1.1.3

## Problem
`pipx run agnostic-prompt-aps init` fails on Windows:
```
NOTE: running app 'aps.exe' from 'agnostic-prompt-aps'
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

## Solution
The `__main__.py` module enables `python -m aps_cli` invocation, which bypasses the Windows console script executable issue entirely. This is also a Python best practice for CLI packages.

## Test plan
- [x] Verify `python -m aps_cli doctor` works locally
- [x] Verify `python -m aps_cli version` works locally
- [x] Verify `python -m aps_cli init --claude --dry-run --yes` works locally
- [ ] After publish: test `pipx run agnostic-prompt-aps doctor` on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)