### PR TITLE
feat: add devcontainer for repeatable dev environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+{
+  "name": "APS Development",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    },
+    "ghcr.io/devcontainers/features/copilot-cli": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/opencode": {},
+    "ghcr.io/devcontainers/features/github-cli": {}  
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "GitHub.copilot"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "always"
+        },
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": "always",
+            "source.organizeImports.ruff": "always"
+          }
+        },
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[javascript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[json]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[markdown]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "python.analysis.typeCheckingMode": "basic"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "==> Installing Node.js dependencies..."
+npm install --prefix packages/aps-cli-node
+
+echo "==> Installing UV (Python package manager)..."
+pip install uv
+
+echo "==> Installing Python CLI with dev dependencies..."
+uv pip install --system -e "packages/aps-cli-py[dev]"
+
+echo "==> Installing Ruff (Python linter/formatter)..."
+pip install ruff
+
+echo "==> Setting up Husky git hooks..."
+npx husky install
+
+echo "==> Development environment ready!"

--- a/packages/aps-cli-node/package-lock.json
+++ b/packages/aps-cli-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agnostic-prompt/aps",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",
@@ -14,6 +14,7 @@
         "zod": "^3.24.0"
       },
       "bin": {
+        "agnostic-prompt-aps": "bin/aps.js",
         "aps": "bin/aps.js"
       },
       "devDependencies": {

--- a/packages/aps-cli-py/src/aps_cli/cli.py
+++ b/packages/aps-cli-py/src/aps_cli/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Optional

--- a/packages/aps-cli-py/src/aps_cli/core.py
+++ b/packages/aps-cli-py/src/aps_cli/core.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Literal, Optional
 
-from .schemas import safe_parse_platform_manifest, normalize_detection_marker
+from .schemas import safe_parse_platform_manifest
 
 SKILL_ID = "agnostic-prompt-standard"
 

--- a/packages/aps-cli-py/tests/test_schemas.py
+++ b/packages/aps-cli-py/tests/test_schemas.py
@@ -4,8 +4,6 @@ import pytest
 from pydantic import ValidationError
 
 from aps_cli.schemas import (
-    PlatformManifest,
-    SkillFrontmatter,
     parse_platform_manifest,
     parse_skill_frontmatter,
     safe_parse_platform_manifest,


### PR DESCRIPTION
Adds devcontainer configuration for consistent development environment.

## Changes
- Add `.devcontainer/devcontainer.json` with TypeScript/Node 20 base + Python 3.12
- Add devcontainer features: copilot-cli, opencode, github-cli
- Add `post-create.sh` to install dependencies (npm, uv, ruff, husky)
- Configure VS Code extensions and settings for TS/Python development
- Fix 4 unused imports detected by ruff

## Acceptance Criteria (all passing)
- [x] devcontainer.json exists and is valid
- [x] Container builds successfully
- [x] UV and Ruff are available in PATH
- [x] Node CLI tests pass (40/40)
- [x] Python CLI tests pass (41/41)
- [x] Husky hooks initialize properly
- [x] Tools scripts run correctly
- [x] `ruff check .` runs without errors

Closes #23