### PR TITLE
feat(spec): add CSV as fourth block constant type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ skill/
       constants/
         constants-json-block-v1.0.0.example.md    JSON block constant syntax example
         constants-text-block-v1.0.0.example.md    TEXT block constant syntax example
+        constants-csv-block-v1.0.0.example.md     CSV block constant syntax example
       formats/
         format-code-changes-full-v1.0.0.example.md        Full file code changes template
         format-code-map-v1.0.0.example.md                 Code snippets with source links
@@ -93,6 +94,7 @@ skill/
         format-ideation-list-v1.0.0.example.md            Structured brainstorming ideas format
         format-link-manifest-v1.0.0.example.md            Link manifest format template
         format-markdown-table-v1.0.0.example.md           Process results table format
+        format-smeac-plan-v1.0.0.example.md               SMEAC-style plan format
         format-table-api-coverage-v1.0.0.example.md       API coverage gap analysis table
     platforms/
       claude-code/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The core abstraction is a structured envelope with seven ordered sections, from 
 ```
 skill/agnostic-prompt-standard/
 ├── assets/
-│   ├── constants/          # Constant syntax examples (JSON, TEXT blocks)
+│   ├── constants/          # Constant syntax examples (JSON, TEXT, CSV blocks)
 │   └── formats/            # Output format templates (tables, outlines, etc.)
 ├── platforms/
 │   ├── vscode-copilot/     # VS Code / Copilot adapter
@@ -141,6 +141,8 @@ python tools/sync_payload.py       # Sync skill to CLI payloads
 python tools/check_versions.py     # Verify version consistency
 python tools/check_skill_links.py  # Check skill link integrity
 python tools/bump_version.py X.Y.Z # Update version across all files
+python tools/test_bump_version.py  # Run bump_version unit tests
+python tools/generate-decision-index.py  # Generate ADR decision index
 ```
 
 ### Testing

--- a/docs/why-aps-exists.md
+++ b/docs/why-aps-exists.md
@@ -155,6 +155,7 @@ APS makes tool usage explicit and auditable. Platform adapters encode tool risk 
 A docs indexer agent produces a documentation map. The format contract:
 
 ```
+<formats>
 <format id="DOCS_INDEX_V1" name="Documentation Index"
         purpose="Token-efficient hierarchical documentation map.">
 # <PROJECT_TITLE> Documentation Map
@@ -176,6 +177,7 @@ WHERE:
 - <HEADING_TEXT> is String; H2/H3 heading text.
 - <SUBHEADING_TEXT> is String; nested heading under parent.
 </format>
+</formats>
 ```
 
 A CI step validates: does the agent's output parse as a single `format:DOCS_INDEX_V1` fenced block? Are all required placeholders resolved? Are timestamps ISO 8601? If not, the build fails with a specific AG-0xx error code. No regex hacking. No "it looks about right."
@@ -218,7 +220,7 @@ The most common adoption path is agent prompts: structured instructions that gov
 The core abstraction is a structured envelope with seven ordered sections:
 
 1. Instructions: directives that govern behavior (one per line, imperative, lintable).
-2. Constants: read-only values resolved before execution (inline, JSON blocks, TEXT blocks, YAML blocks).
+2. Constants: read-only values resolved before execution (inline, JSON blocks, TEXT blocks, YAML blocks, CSV blocks).
 3. Formats: output contracts with placeholders, types, and WHERE clauses.
 4. Runtime: environment-specific bindings (dev, staging, prod).
 5. Triggers: event-to-process mappings.

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   co_authors: "Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
   framework_revision: "1.1.11"
-  last_updated: "2026-01-15"
+  last_updated: "2026-02-18"
 ---
 
 # Agnostic Prompt Standard (APS) v1.0 — Skill Entry
@@ -37,6 +37,7 @@ This `SKILL.md` is the **entrypoint** for the Agnostic Prompt Standard (APS) v1.
   - `constants/` — example constants blocks.
     - `constants-json-block-v1.0.0.example.md`
     - `constants-text-block-v1.0.0.example.md`
+    - `constants-csv-block-v1.0.0.example.md`
   - `formats/` — example format blocks.
     - `format-code-changes-full-v1.0.0.example.md`
     - `format-code-map-v1.0.0.example.md`

--- a/skill/agnostic-prompt-standard/assets/constants/constants-csv-block-v1.0.0.example.md
+++ b/skill/agnostic-prompt-standard/assets/constants/constants-csv-block-v1.0.0.example.md
@@ -1,0 +1,13 @@
+<!-- Example: multi-line CSV constant using CSV<< ... >>.
+     Engines parse BODY as CSV then compile it to canonical JSON rows (see 00 Structure / 02 Linting). -->
+
+<constants>
+DEFAULT_TZ: "Z"
+
+SERVICE_TABLE: CSV<<
+service,region,default_tz,enabled,note
+billing,us-east-1,DEFAULT_TZ,true,"Primary billing region"
+support,ap-southeast-2,"Australia/Brisbane",true,"Escalations use ""follow the sun"""
+reporting,eu-west-1,DEFAULT_TZ,false,"EU, West"
+>>
+</constants>

--- a/skill/agnostic-prompt-standard/assets/constants/constants-json-block-v1.0.0.example.md
+++ b/skill/agnostic-prompt-standard/assets/constants/constants-json-block-v1.0.0.example.md
@@ -1,7 +1,7 @@
-<constants>
-// Example: multi-line JSON constant using JSON<< ... >>.
-// Engines parse BODY as JsonValue then compile it to canonical JSON (see json_spacing).
+<!-- Example: multi-line JSON constant using JSON<< ... >>.
+     Engines parse BODY as JsonValue then compile it to canonical JSON (see json_spacing). -->
 
+<constants>
 DEFAULT_TZ: "Z"
 
 API_CONFIG: JSON<<

--- a/skill/agnostic-prompt-standard/assets/constants/constants-text-block-v1.0.0.example.md
+++ b/skill/agnostic-prompt-standard/assets/constants/constants-text-block-v1.0.0.example.md
@@ -1,7 +1,7 @@
-<constants>
-// Example: multi-line TEXT constant using TEXT<< ... >>.
-// NOTE: Comment stripping (//) does NOT apply inside TEXT<< bodies.
+<!-- Example: multi-line TEXT constant using TEXT<< ... >>.
+     NOTE: Comment stripping (//) does NOT apply inside TEXT<< bodies. -->
 
+<constants>
 REPO_TREE: TEXT<<
 cb-agnostic-prompt-protocol
 ├── assets

--- a/skill/agnostic-prompt-standard/references/00-structure.md
+++ b/skill/agnostic-prompt-standard/references/00-structure.md
@@ -50,7 +50,7 @@ Constants MUST use one of the following forms:
 1. Inline constant: `SYMBOL: VALUE` where `VALUE` is `String | Number | Boolean | JSON`.
 2. Block constant: `SYMBOL: <BLOCK_TYPE><<` then BODY lines then a closing delimiter line `>>`.
 
-`<BLOCK_TYPE>` MUST be one of: `JSON`, `TEXT`, `YAML`.
+`<BLOCK_TYPE>` MUST be one of: `JSON`, `TEXT`, `YAML`, `CSV`.
 
 Block constant opening lines MUST:
 
@@ -62,13 +62,14 @@ Valid openers:
 - `SYMBOL: JSON<<`
 - `SYMBOL: TEXT<<`
 - `SYMBOL: YAML<<`
+- `SYMBOL: CSV<<`
 
 Block constant closing delimiter MUST be a line whose content is exactly `>>` starting at column 1
 (no leading/trailing whitespace).
 
 ### JSON block constants
 
-- BODY MUST parse as `JsonValue` per **05 Grammar**.
+- BODY MUST parse as `JsonValue` per **05 Grammar**; invalid JSON → `AG-007`.
 - Any `UpperSym` that appears inside a JSON block constant BODY MUST resolve from `<constants>`
   before execution; unresolved → `AG-006`.
 - Engines MUST compile JSON block constants to canonical JSON that conforms to `json_spacing` and
@@ -84,16 +85,49 @@ Block constant closing delimiter MUST be a line whose content is exactly `>>` st
 
 ### YAML block constants
 
-- BODY MUST parse as valid YAML.
+- BODY MUST parse as valid YAML; invalid YAML → `AG-047`.
 - Any `UpperSym` that appears inside a YAML block constant BODY MUST resolve from `<constants>`
   before execution; unresolved → `AG-006`.
 - Engines MUST compile YAML block constants to canonical YAML with lexicographic key ordering and
   consistent indentation (see **02 Linting and formatting**).
 
+### CSV block constants
+
+CSV blocks are for compact tabular data.
+
+- BODY MUST parse as CSV (comma-separated values) using the rules below; invalid CSV → `AG-048`.
+- Separator is `,` (comma).
+- Quote character is `"` (double quote).
+- First record is the header row.
+  - Header fields MUST be unquoted.
+  - Header fields MUST match `JsonKey` per **05 Grammar**.
+  - Header fields MUST be unique.
+- Each subsequent record MUST have the same number of fields as the header row (ragged rows are
+  forbidden).
+- Quoted cell values:
+  - MUST follow RFC 4180 quoting (`""` escapes `"`).
+  - Are always treated as `String` (no constant substitution).
+- Unquoted cell values are parsed in this order:
+  1. If the full cell matches `UpperSym`, it denotes a constant symbol reference.
+     - Engines MUST resolve it from `<constants>` before execution; unresolved → `AG-006`.
+     - The referenced constant MUST be a scalar (`String | Number | Boolean | null`) or the engine
+       MUST raise `AG-048`.
+  2. If the cell matches JSON scalars (`Number`, `true`, `false`, `null`), it becomes that JSON
+     scalar.
+  3. Otherwise the cell is a `String` (no trimming).
+- Engines MUST compile CSV block constants to canonical JSON as a `JsonArr` of `JsonObj` rows using
+  header fields as keys (see **02 Linting and formatting**).
+  - Record order MUST be preserved.
+  - Row object keys MUST be emitted in lexicographic order in canonical JSON form.
+
 ### Block type selection guidance
+
+Prefer CSV blocks for compact tabular data with a header row and consistent columns.
 
 Prefer YAML blocks for structured data unless JSON has a specific advantage (e.g., the constant
 represents an actual JSON payload or JSON Schema).
+
+Prefer TEXT blocks only when the constant must remain opaque (verbatim).
 
 ## `<processes>` section
 

--- a/skill/agnostic-prompt-standard/references/02-linting-and-formatting.md
+++ b/skill/agnostic-prompt-standard/references/02-linting-and-formatting.md
@@ -55,6 +55,21 @@ Engines that compile or canonicalize YAML MUST emit **canonical YAML** using the
 Source form inside YAML block constants MAY contain arbitrary formatting, but engines MUST parse
 and re-emit canonical YAML at compile time.
 
+## Canonical CSV compilation
+
+Engines that compile CSV block constants MUST:
+
+- Parse CSV per **00 Structure** (header row rules, quoting rules, row width rules).
+- Compile the result to canonical JSON using the rules in **Canonical JSON spacing**.
+- Preserve CSV record order in the compiled JSON array.
+
+If an engine also emits canonical CSV (informative), it SHOULD:
+
+- Use `,` as the separator and `"` as the quote character.
+- Quote a field only when required (contains `,`, `"`, or newline, or has leading/trailing space).
+- Escape `"` as `""` inside quoted fields.
+- Use LF newlines and emit no trailing whitespace.
+
 ## `where:` key ordering
 
 In `where:` parameter lists, keys MUST appear in lexicographic order. Violation → `AG-012`.
@@ -75,18 +90,37 @@ Violation → `AG-003` (InvalidId).
 An `UpperSym` appearing inside JSON objects/arrays denotes a **constant symbol reference**.
 Engines MUST resolve it from `<constants>` before execution or raise `AG-006`.
 
+## Constants inside YAML values
+
+An `UpperSym` appearing inside YAML mappings/sequences/scalars denotes a **constant symbol
+reference**.
+
+Engines MUST resolve it from `<constants>` before execution or raise `AG-006`.
+
+## Constants inside CSV values
+
+In a CSV block constant, an unquoted cell whose full content matches `UpperSym` denotes a
+**constant symbol reference**.
+
+- Engines MUST resolve it from `<constants>` before execution or raise `AG-006`.
+- The referenced constant MUST resolve to a scalar (`String | Number | Boolean | null`) or the
+  engine MUST raise `AG-048`.
+
 ## Block constants
 
 Block constants are allowed only inside `<constants>` (see **00 Structure**).
 
 Rules:
 
-- Block constant opening line MUST be `SYMBOL: JSON<<`, `SYMBOL: TEXT<<`, or `SYMBOL: YAML<<`
-  (exactly one ASCII space after `:`).
+- Block constant opening line MUST be `SYMBOL: JSON<<`, `SYMBOL: TEXT<<`, `SYMBOL: YAML<<`, or
+  `SYMBOL: CSV<<` (exactly one ASCII space after `:`).
 - Block constant BODY is line-oriented and terminates at the first line whose content is exactly
   `>>` starting at column 1.
 - Unknown `<BLOCK_TYPE>` → `AG-046`.
 - Missing closing delimiter `>>` → `AG-045`.
+- Invalid JSON block constant BODY → `AG-007`.
+- Invalid YAML block constant BODY → `AG-047`.
+- Invalid CSV block constant BODY → `AG-048`.
 
 ## Format blocks
 

--- a/skill/agnostic-prompt-standard/references/04-schemas-and-types.md
+++ b/skill/agnostic-prompt-standard/references/04-schemas-and-types.md
@@ -49,7 +49,7 @@ Placeholders and WHERE sections are normative (see also **02 Linting and formatt
 - Every `<format>` body MUST end with a `WHERE:` section that defines each placeholder exactly
   once.
 - Each WHERE definition line MUST begin with `- <PLACEHOLDER> …` and normatively constrain the
-  placeholder (e.g., “is …”, “∈ { … }”, “matches …”, “format: …”, “example: …”).
+  placeholder (e.g., “is …”, “∈ { … }”, “matches …”, “example: …”).
 - No placeholder may appear in the body if it is not defined in WHERE → `AG-042`.
 - No placeholder may be defined in WHERE if it does not appear in the body → `AG-042`.
 - Any non-`<…>` placeholder notation (e.g., `{placeholder}`, `$PLACEHOLDER`) is forbidden →
@@ -132,4 +132,4 @@ Style guidelines:
 
 - JSON block constant example: [../assets/constants/constants-json-block-v1.0.0.example.md](../assets/constants/constants-json-block-v1.0.0.example.md)
 - TEXT block constant example: [../assets/constants/constants-text-block-v1.0.0.example.md](../assets/constants/constants-text-block-v1.0.0.example.md)
-
+- CSV block constant example: [../assets/constants/constants-csv-block-v1.0.0.example.md](../assets/constants/constants-csv-block-v1.0.0.example.md)

--- a/skill/agnostic-prompt-standard/references/05-grammar.md
+++ b/skill/agnostic-prompt-standard/references/05-grammar.md
@@ -22,7 +22,7 @@ Number        = "-"? Digit, { Digit }, [ ".", Digit, { Digit } ] ;
 String        = "\"", { <any char except " or \"> | "\\\"" | "\\\\" }, "\"" ;
 EnumLit       = "enum(", UpperSym, { ",", UpperSym }, ")" ;
 
-BlockType     = "JSON" | "TEXT" | "YAML" ;
+BlockType     = "JSON" | "TEXT" | "YAML" | "CSV" ;
 BlockOpen     = UpperSym, ":", Space, BlockType, "<<", EOL ;
 BlockClose    = ">>" ;
 BlockValue    = BlockType, "<<", EOL, { <any line except BlockClose>, EOL }, BlockClose ;

--- a/skill/agnostic-prompt-standard/references/07-error-taxonomy.md
+++ b/skill/agnostic-prompt-standard/references/07-error-taxonomy.md
@@ -48,7 +48,9 @@ errors:
     - { code: AG-043, name: PlaceholderStyleError, desc: Placeholder not in <UPPER_SNAKE> form or not wrapped in angle brackets. }
     - { code: AG-044, name: ProcessArgsMismatch, desc: RUN statement arguments do not match the target process signature (missing, extra, or type-incompatible arguments). }
     - { code: AG-045, name: BlockConstantUnterminated, desc: Block constant missing closing delimiter line >>. }
-    - { code: AG-046, name: BlockConstantTypeUnknown, desc: Block constant uses unknown <BLOCK_TYPE>; expected JSON, TEXT, or YAML. }
+    - { code: AG-046, name: BlockConstantTypeUnknown, desc: Block constant uses unknown <BLOCK_TYPE>; expected JSON, TEXT, YAML, or CSV. }
+    - { code: AG-047, name: BadYAML, desc: Invalid YAML block constant body. }
+    - { code: AG-048, name: BadCSV, desc: Invalid CSV block constant body (parse failure, invalid header, ragged rows, or invalid cell). }
 
   warnings:
     - { code: AG-W01, name: SymbolNotUsed, desc: Defined but never used. }


### PR DESCRIPTION
## Summary

Add `CSV` as a fourth block constant type alongside `JSON`, `TEXT`, and `YAML`, giving prompt authors a compact tabular syntax for row-oriented data like configuration tables, service registries, and lookup maps. Also fills a gap in the error taxonomy by adding a dedicated YAML parse-error code.

Closes #41

## Motivation

Tabular data encoded as JSON arrays of objects or YAML sequences of mappings is verbose and obscures the columnar structure. A 4-column, 3-row table takes ~15 lines of JSON but only 4 lines of CSV. For constants that are conceptually tables, CSV communicates intent immediately and compiles to the same canonical JSON representation.

Additionally, YAML block constants had no dedicated parse-error code (JSON had `AG-007`), which this change corrects alongside the CSV work.

## Changes

### Change Tree
```
# Legend: A = Added, M = Modified

skill/agnostic-prompt-standard/
├── SKILL.md                                                    # M: last_updated, register CSV example
├── assets/constants/
│   ├── constants-csv-block-v1.0.0.example.md                  # A: CSV block example (constant refs, quoting, escaping)
│   ├── constants-json-block-v1.0.0.example.md                 # M: move comments outside <constants> tag
│   └── constants-text-block-v1.0.0.example.md                 # M: move comments outside <constants> tag
├── references/
│   ├── 00-structure.md                                         # M: CSV block syntax, cell parsing, selection guidance
│   ├── 02-linting-and-formatting.md                            # M: canonical CSV compilation, constant resolution
│   ├── 04-schemas-and-types.md                                 # M: link to CSV example, minor cleanup
│   ├── 05-grammar.md                                           # M: CSV in BlockType production
│   └── 07-error-taxonomy.md                                    # M: AG-047 (BadYAML), AG-048 (BadCSV)

AGENTS.md                                                       # M: CSV example in SKILL_TREE constant
README.md                                                       # M: constants description, missing tool refs
docs/why-aps-exists.md                                          # M: CSV in envelope section, fix <formats> wrapper
```

### Details

**Normative spec changes**
- `00-structure.md`: Full CSV block definition — comma separator, RFC 4180 quoting, header row rules (`JsonKey`, unique), ragged-row prohibition, cell value parsing order (constant ref via `UpperSym` → JSON scalar → string), compilation to `JsonArr` of `JsonObj`. Updated block type selection guidance: CSV for tabular data, YAML for structured data, TEXT for verbatim.
- `02-linting-and-formatting.md`: Canonical CSV compilation rules (parse → canonical JSON, preserve record order). Constant resolution for unquoted cells matching `UpperSym`. Also added missing YAML constant resolution section for parity.
- `05-grammar.md`: `BlockType = "JSON" | "TEXT" | "YAML" | "CSV"`.
- `07-error-taxonomy.md`: `AG-047 BadYAML` (fills existing gap), `AG-048 BadCSV` (parse failure, invalid header, ragged rows, invalid cell).

**Example asset**
- New `constants-csv-block-v1.0.0.example.md`: `SERVICE_TABLE: CSV<<` with constant references (`DEFAULT_TZ`), quoted strings with embedded commas, and RFC 4180 escaped quotes (`""`).

**Existing asset fixes**
- JSON and TEXT example files: moved HTML comments from inside `<constants>` (using `//` syntax) to outside (using `<!-- -->` syntax), since `//` comments inside sections are forbidden per spec.

**Documentation updates**
- `SKILL.md`: `last_updated` → 2026-02-18, CSV example added to file tree listing.
- `AGENTS.md`: CSV example added to `SKILL_TREE` constant.
- `README.md`: Constants description now mentions CSV; added missing tool references.
- `docs/why-aps-exists.md`: CSV in envelope section; fixed missing `<formats>` wrapper in code example.

## Testing

1. Manual review:
   - CSV example asset validates against the rules defined in `00-structure.md`
   - All cross-references between spec documents are consistent
   - EBNF grammar production is syntactically correct

2. Link integrity:
   - `04-schemas-and-types.md` CSV example link resolves to the new asset file

## Checklist

- [x] `BlockType` grammar production includes `CSV`
- [x] `00-structure.md` defines CSV block syntax with header rules, quoting, cell parsing, compilation target
- [x] `02-linting-and-formatting.md` defines canonical CSV compilation and constant resolution
- [x] `07-error-taxonomy.md` includes `AG-047` (BadYAML) and `AG-048` (BadCSV)
- [x] CSV example asset demonstrates constant refs, quoted strings, RFC 4180 escaping
- [x] Existing JSON/TEXT examples have comments outside `<constants>` tags
- [x] All cross-references updated (SKILL.md, AGENTS.md, README, schemas doc, why-aps-exists)
- [x] No version bump (spec-only change within current framework revision)
- [x] No CLI changes required