### PR TITLE
chore: bump version to 1.1.16

### DIFF
--- a/packages/aps-cli-node/package.json
+++ b/packages/aps-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates.",
   "type": "module",
   "bin": {

--- a/packages/aps-cli-py/pyproject.toml
+++ b/packages/aps-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agnostic-prompt-aps"
-version = "1.1.15"
+version = "1.1.16"
 description = "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/aps-cli-py/src/aps_cli/__init__.py
+++ b/packages/aps-cli-py/src/aps_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: "Christopher Buckley"
   co_authors: "Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
-  framework_revision: "1.1.15"
+  framework_revision: "1.1.16"
   last_updated: "2026-02-18"
 ---
 

--- a/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
@@ -76,13 +76,21 @@ AGENT_VERSIONING: JSON<<
   "templates": [
     {
       "path": "templates/.claude/agents/aps-v{major}.{minor}.{patch}.md",
-      "current_path": "templates/.claude/agents/aps-v1.1.15.md",
+      "current_path": "templates/.claude/agents/aps-v1.1.16.md",
       "frontmatter": {
         "name_pattern": "aps-v{major}-{minor}-{patch}",
         "description_pattern": "Generate APS v{major}.{minor}.{patch} agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint."
       }
     }
   ]
+}
+>>
+
+SKILL_AUTHORING_RESOURCES: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
 }
 >>
 

--- a/skill/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.1.16.md
+++ b/skill/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.1.16.md
@@ -1,23 +1,18 @@
 ---
-name: APS v1.1.15 Agent
-description: "Generate APS v1.1.15 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
-tools:
-  - execute/runInTerminal
-  - read/readFile
-  - edit/createDirectory
-  - edit/createFile
-  - edit/editFiles
-  - web/fetch
-  - todo
-user-invokable: true
-disable-model-invocation: true
-target: vscode
+name: aps-v1-1-16
+description: "Generate APS v1.1.16 agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+model: inherit
+tools: Read, Write, Glob, Grep, Bash, TodoWrite
+disallowedTools: Edit, MultiEdit
+permissionMode: default
 ---
 
 <instructions>
 You MUST follow APS v1.0 section order and the tag newline rule.
 You MUST keep one directive per line inside <instructions>.
 You MUST load SKILL_PATH once per session before probing.
+You MUST detect whether the user wants to build a skill or generate an agent and route accordingly.
+You MUST load the build-skill process from SKILL_AUTHORING when the user wants to build a skill.
 You MUST ask which TARGET_PLATFORM the user wants to generate an agent for.
 You MUST load the target platform's adaptor.md before generating.
 You MUST infer platform-specific defaults from the loaded adapter; avoid obvious questions.
@@ -52,56 +47,63 @@ You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
 <constants>
-SKILL_PATH: ".github/skills/agnostic-prompt-standard/SKILL.md"
-SKILL_PATH_ALT: ".claude/skills/agnostic-prompt-standard/SKILL.md"
-PLATFORMS_BASE: ".github/skills/agnostic-prompt-standard/platforms"
-PLATFORMS_BASE_ALT: ".claude/skills/agnostic-prompt-standard/platforms"
+SKILL_PATH: ".claude/skills/agnostic-prompt-standard/SKILL.md"
+SKILL_PATH_ALT: ".github/skills/agnostic-prompt-standard/SKILL.md"
+PLATFORMS_BASE: ".claude/skills/agnostic-prompt-standard/platforms"
+PLATFORMS_BASE_ALT: ".github/skills/agnostic-prompt-standard/platforms"
+
+SKILL_AUTHORING: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
+}
+>>
+
 CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
 PLATFORMS: JSON<<
 {
-  "vscode-copilot": {
-    "displayName": "VS Code Copilot",
-    "adaptorPath": "vscode-copilot/adaptor.md",
-    "agentsDir": ".github/agents/",
-    "agentExt": ".agent.md",
-    "toolSyntax": "yaml-array"
-  },
-  "claude-code": {
-    "displayName": "Claude Code",
-    "adaptorPath": "claude-code/adaptor.md",
-    "agentsDir": ".claude/agents/",
-    "agentExt": ".md",
-    "toolSyntax": "comma-separated"
-  }
+"vscode-copilot": {
+"displayName": "VS Code Copilot",
+"adaptorPath": "vscode-copilot/adaptor.md",
+"agentsDir": ".github/agents/",
+"agentExt": ".agent.md",
+"toolSyntax": "yaml-array"
+},
+"claude-code": {
+"displayName": "Claude Code",
+"adaptorPath": "claude-code/adaptor.md",
+"agentsDir": ".claude/agents/",
+"agentExt": ".md",
+"toolSyntax": "comma-separated"
+}
 }
 >>
 
 FIELD_REQUIREMENTS_VSCODE: JSON<<
 {
-  "required": ["name", "description"],
-  "recommended": {
-    "tools": [],
-    "user-invokable": true,
-    "disable-model-invocation": false,
-    "target": "vscode"
-  },
-  "conditional": ["model", "argument-hint", "agents", "mcp-servers", "handoffs"],
-  "fieldOrder": ["name", "description", "tools", "user-invokable", "disable-model-invocation", "target", "model", "argument-hint", "agents", "mcp-servers", "handoffs"],
-  "deprecated": ["infer"]
+"required": ["name", "description"],
+"recommended": {
+"tools": [],
+"infer": true,
+"target": "vscode"
+},
+"conditional": ["model", "argument-hint", "mcp-servers", "handoffs"],
+"fieldOrder": ["name", "description", "tools", "infer", "target", "model", "argument-hint", "mcp-servers", "handoffs"]
 }
 >>
 
 FIELD_REQUIREMENTS_CLAUDE: JSON<<
 {
-  "required": ["name", "description"],
-  "recommended": {
-    "tools": "Read, Grep, Glob",
-    "model": "inherit",
-    "permissionMode": "default"
-  },
-  "conditional": ["disallowedTools", "skills", "hooks"],
-  "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
+"required": ["name", "description"],
+"recommended": {
+"tools": "Read, Grep, Glob",
+"model": "inherit",
+"permissionMode": "default"
+},
+"conditional": ["disallowedTools", "skills", "hooks"],
+"fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
 }
 >>
 
@@ -153,8 +155,7 @@ LINT_CHECKS: TEXT<<
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
-- VS Code: tools is YAML array, user-invokable is boolean, disable-model-invocation is boolean, target is string
-- VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
+- VS Code: tools is YAML array, infer is boolean, target is string
 - Claude Code: tools is comma-separated string, model is string, permissionMode is string
 - generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
 - generated <instructions> has one directive per line with no blank lines
@@ -352,6 +353,7 @@ AGENT: ""
 LINT: ""
 LINT_CLEAN: false
 FIELD_REQUIREMENTS: {}
+INTENT_MODE: ""
 </runtime>
 
 <triggers>
@@ -362,6 +364,11 @@ FIELD_REQUIREMENTS: {}
 <process id="router" name="Route">
 IF SESSION_INIT is false:
   RUN `init`
+IF INTENT_MODE is empty:
+  SET INTENT_MODE := <MODE> (from "Agent Inference" using USER_INPUT)
+IF INTENT_MODE = "skill":
+  RUN `load-skill-builder`
+  RETURN
 IF TARGET_PLATFORM is empty:
   RUN `ask-platform`
   RETURN: format="ASK_V1", cta=CTA, intent=INTENT, questions=QUESTIONS, state=STATE
@@ -388,14 +395,16 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-READ file at SKILL_PATH or SKILL_PATH_ALT
-CAPTURE SKILL_CONTENT from read result
+USE `Glob` where: pattern=".claude/skills/agnostic-prompt-standard/SKILL.md,.github/skills/agnostic-prompt-standard/SKILL.md"
+CAPTURE SKILL_PATHS from `Glob`
+USE `Read` where: filePath=SKILL_PATHS[0]
+CAPTURE SKILL_CONTENT from `Read`
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
 SET STATE := "Selecting target platform" (from "Agent Inference")
 SET INTENT := "Target platform not yet selected" (from "Agent Inference")
-SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (VS Code Copilot)\n  e) None / Cancel" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (Claude Code)\n  e) None / Cancel" (from "Agent Inference")
 SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
 IF TARGET_PLATFORM is not empty:
   RUN `load-platform`
@@ -404,8 +413,14 @@ IF TARGET_PLATFORM is not empty:
 <process id="load-platform" name="Load Platform Adapter">
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
-READ file at ADAPTOR_PATH (fallback to PLATFORMS_BASE_ALT if not found)
-CAPTURE ADAPTOR_CONTENT from read result
+USE `Glob` where: pattern=ADAPTOR_PATH
+CAPTURE ADAPTOR_PATHS from `Glob`
+IF ADAPTOR_PATHS is empty:
+  SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
+  USE `Glob` where: pattern=ADAPTOR_PATH
+  CAPTURE ADAPTOR_PATHS from `Glob`
+USE `Read` where: filePath=ADAPTOR_PATHS[0]
+CAPTURE ADAPTOR_CONTENT from `Read`
 SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
 SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
 IF TARGET_PLATFORM = "claude-code":
@@ -428,10 +443,22 @@ ELSE:
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `edit/createDirectory` where: dirPath=PLATFORM_CONFIG.agentsDir
-USE `edit/createFile` where: filePath=FILE_PATH, content=AGENT
+USE `Bash` where: command="mkdir -p " + PLATFORM_CONFIG.agentsDir
+USE `Write` where: filePath=FILE_PATH, content=AGENT
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
+</process>
+
+<process id="load-skill-builder" name="Load Skill Builder">
+SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
+SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
+USE `Read` where: filePath=BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from `Read`
+SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
+USE `Read` where: filePath=GUIDE_PATH
+CAPTURE GUIDE_CONTENT from `Read`
+SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
+TELL "Skill builder loaded. Following build-skill process workflow." level=brief
 </process>
 </processes>
 

--- a/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
@@ -82,13 +82,21 @@ AGENT_VERSIONING: JSON<<
   "templates": [
     {
       "path": "templates/.github/agents/aps-v{major}.{minor}.{patch}.agent.md",
-      "current_path": "templates/.github/agents/aps-v1.1.15.agent.md",
+      "current_path": "templates/.github/agents/aps-v1.1.16.agent.md",
       "frontmatter": {
         "name_pattern": "APS v{major}.{minor}.{patch} Agent",
         "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint."
       }
     }
   ]
+}
+>>
+
+SKILL_AUTHORING_RESOURCES: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
 }
 >>
 
@@ -106,7 +114,7 @@ DOCS_CUSTOM_INSTRUCTIONS_URL: "https://code.visualstudio.com/docs/copilot/custom
 name: <AGENT_NAME>
 description: "<AGENT_DESCRIPTION>"
 tools: <TOOLS_ARRAY>
-user-invokable: <USER_INVOKABLE>
+user-invocable: <USER_INVOCABLE>
 disable-model-invocation: <DISABLE_MODEL_INVOCATION>
 target: <TARGET>
 ---
@@ -115,7 +123,7 @@ WHERE:
 - <AGENT_NAME> is String; the agent identifier shown in UI.
 - <AGENT_DESCRIPTION> is String; single-line quoted string describing agent purpose.
 - <TOOLS_ARRAY> is YAML array of tool qualified names or toolset names from TOOLS constant.
-- <USER_INVOKABLE> is Boolean; true if agent appears in the agents dropdown; default true.
+- <USER_INVOCABLE> is Boolean; true if agent appears in the agents dropdown; default true.
 - <DISABLE_MODEL_INVOCATION> is Boolean; true to prevent invocation as subagent; default false.
 - <TARGET> is one of: "vscode", "github-copilot"; default "vscode".
 </format>

--- a/skill/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.1.16.agent.md
+++ b/skill/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.1.16.agent.md
@@ -1,16 +1,25 @@
 ---
-name: aps-v1-1-15
-description: "Generate APS v1.1.15 agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
-model: inherit
-tools: Read, Write, Glob, Grep, Bash, TodoWrite
-disallowedTools: Edit, MultiEdit
-permissionMode: default
+name: APS v1.1.16 Agent
+description: "Generate APS v1.1.16 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+tools:
+  - execute/runInTerminal
+  - read/readFile
+  - edit/createDirectory
+  - edit/createFile
+  - edit/editFiles
+  - web/fetch
+  - todo
+user-invocable: true
+disable-model-invocation: true
+target: vscode
 ---
 
 <instructions>
 You MUST follow APS v1.0 section order and the tag newline rule.
 You MUST keep one directive per line inside <instructions>.
 You MUST load SKILL_PATH once per session before probing.
+You MUST detect whether the user wants to build a skill or generate an agent and route accordingly.
+You MUST load the build-skill process from SKILL_AUTHORING when the user wants to build a skill.
 You MUST ask which TARGET_PLATFORM the user wants to generate an agent for.
 You MUST load the target platform's adaptor.md before generating.
 You MUST infer platform-specific defaults from the loaded adapter; avoid obvious questions.
@@ -45,54 +54,65 @@ You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
 <constants>
-SKILL_PATH: ".claude/skills/agnostic-prompt-standard/SKILL.md"
-SKILL_PATH_ALT: ".github/skills/agnostic-prompt-standard/SKILL.md"
-PLATFORMS_BASE: ".claude/skills/agnostic-prompt-standard/platforms"
-PLATFORMS_BASE_ALT: ".github/skills/agnostic-prompt-standard/platforms"
+SKILL_PATH: ".github/skills/agnostic-prompt-standard/SKILL.md"
+SKILL_PATH_ALT: ".claude/skills/agnostic-prompt-standard/SKILL.md"
+PLATFORMS_BASE: ".github/skills/agnostic-prompt-standard/platforms"
+PLATFORMS_BASE_ALT: ".claude/skills/agnostic-prompt-standard/platforms"
+
+SKILL_AUTHORING: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
+}
+>>
+
 CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
 PLATFORMS: JSON<<
 {
-"vscode-copilot": {
-"displayName": "VS Code Copilot",
-"adaptorPath": "vscode-copilot/adaptor.md",
-"agentsDir": ".github/agents/",
-"agentExt": ".agent.md",
-"toolSyntax": "yaml-array"
-},
-"claude-code": {
-"displayName": "Claude Code",
-"adaptorPath": "claude-code/adaptor.md",
-"agentsDir": ".claude/agents/",
-"agentExt": ".md",
-"toolSyntax": "comma-separated"
-}
+  "vscode-copilot": {
+    "displayName": "VS Code Copilot",
+    "adaptorPath": "vscode-copilot/adaptor.md",
+    "agentsDir": ".github/agents/",
+    "agentExt": ".agent.md",
+    "toolSyntax": "yaml-array"
+  },
+  "claude-code": {
+    "displayName": "Claude Code",
+    "adaptorPath": "claude-code/adaptor.md",
+    "agentsDir": ".claude/agents/",
+    "agentExt": ".md",
+    "toolSyntax": "comma-separated"
+  }
 }
 >>
 
 FIELD_REQUIREMENTS_VSCODE: JSON<<
 {
-"required": ["name", "description"],
-"recommended": {
-"tools": [],
-"infer": true,
-"target": "vscode"
-},
-"conditional": ["model", "argument-hint", "mcp-servers", "handoffs"],
-"fieldOrder": ["name", "description", "tools", "infer", "target", "model", "argument-hint", "mcp-servers", "handoffs"]
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": [],
+    "user-invocable": true,
+    "disable-model-invocation": false,
+    "target": "vscode"
+  },
+  "conditional": ["model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "fieldOrder": ["name", "description", "tools", "user-invocable", "disable-model-invocation", "target", "model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "deprecated": ["infer", "user-invokable"]
 }
 >>
 
 FIELD_REQUIREMENTS_CLAUDE: JSON<<
 {
-"required": ["name", "description"],
-"recommended": {
-"tools": "Read, Grep, Glob",
-"model": "inherit",
-"permissionMode": "default"
-},
-"conditional": ["disallowedTools", "skills", "hooks"],
-"fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": "Read, Grep, Glob",
+    "model": "inherit",
+    "permissionMode": "default"
+  },
+  "conditional": ["disallowedTools", "skills", "hooks"],
+  "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
 }
 >>
 
@@ -144,7 +164,9 @@ LINT_CHECKS: TEXT<<
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
-- VS Code: tools is YAML array, infer is boolean, target is string
+- VS Code: tools is YAML array, user-invocable is boolean, disable-model-invocation is boolean, target is string
+- VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
+- VS Code: deprecated `user-invokable` field MUST NOT appear in generated frontmatter
 - Claude Code: tools is comma-separated string, model is string, permissionMode is string
 - generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
 - generated <instructions> has one directive per line with no blank lines
@@ -342,6 +364,7 @@ AGENT: ""
 LINT: ""
 LINT_CLEAN: false
 FIELD_REQUIREMENTS: {}
+INTENT_MODE: ""
 </runtime>
 
 <triggers>
@@ -352,6 +375,11 @@ FIELD_REQUIREMENTS: {}
 <process id="router" name="Route">
 IF SESSION_INIT is false:
   RUN `init`
+IF INTENT_MODE is empty:
+  SET INTENT_MODE := <MODE> (from "Agent Inference" using USER_INPUT)
+IF INTENT_MODE = "skill":
+  RUN `load-skill-builder`
+  RETURN
 IF TARGET_PLATFORM is empty:
   RUN `ask-platform`
   RETURN: format="ASK_V1", cta=CTA, intent=INTENT, questions=QUESTIONS, state=STATE
@@ -378,16 +406,14 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-USE `Glob` where: pattern=".claude/skills/agnostic-prompt-standard/SKILL.md,.github/skills/agnostic-prompt-standard/SKILL.md"
-CAPTURE SKILL_PATHS from `Glob`
-USE `Read` where: filePath=SKILL_PATHS[0]
-CAPTURE SKILL_CONTENT from `Read`
+READ file at SKILL_PATH or SKILL_PATH_ALT
+CAPTURE SKILL_CONTENT from read result
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
 SET STATE := "Selecting target platform" (from "Agent Inference")
 SET INTENT := "Target platform not yet selected" (from "Agent Inference")
-SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (Claude Code)\n  e) None / Cancel" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (VS Code Copilot)\n  e) None / Cancel" (from "Agent Inference")
 SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
 IF TARGET_PLATFORM is not empty:
   RUN `load-platform`
@@ -396,14 +422,8 @@ IF TARGET_PLATFORM is not empty:
 <process id="load-platform" name="Load Platform Adapter">
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
-USE `Glob` where: pattern=ADAPTOR_PATH
-CAPTURE ADAPTOR_PATHS from `Glob`
-IF ADAPTOR_PATHS is empty:
-  SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
-  USE `Glob` where: pattern=ADAPTOR_PATH
-  CAPTURE ADAPTOR_PATHS from `Glob`
-USE `Read` where: filePath=ADAPTOR_PATHS[0]
-CAPTURE ADAPTOR_CONTENT from `Read`
+READ file at ADAPTOR_PATH (fallback to PLATFORMS_BASE_ALT if not found)
+CAPTURE ADAPTOR_CONTENT from read result
 SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
 SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
 IF TARGET_PLATFORM = "claude-code":
@@ -426,10 +446,22 @@ ELSE:
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `Bash` where: command="mkdir -p " + PLATFORM_CONFIG.agentsDir
-USE `Write` where: filePath=FILE_PATH, content=AGENT
+USE `edit/createDirectory` where: dirPath=PLATFORM_CONFIG.agentsDir
+USE `edit/createFile` where: filePath=FILE_PATH, content=AGENT
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
+</process>
+
+<process id="load-skill-builder" name="Load Skill Builder">
+SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
+SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
+READ file at BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from read result
+SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
+READ file at GUIDE_PATH
+CAPTURE GUIDE_CONTENT from read result
+SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
+TELL "Skill builder loaded. Following build-skill process workflow." level=brief
 </process>
 </processes>
 


### PR DESCRIPTION
## Summary
- Bump version `1.1.15` → `1.1.16` across all sources (SKILL.md, package.json, pyproject.toml, `__init__.py`)
- Rename versioned agent templates: `aps-v1.1.15` → `aps-v1.1.16` (Claude Code + VS Code Copilot)
- Update `AGENT_VERSIONING` blocks in platform adaptor.md files
- VS Code: rename deprecated `user-invokable` frontmatter field to `user-invocable` (format contract, field requirements, agent template)
- VS Code: add `user-invokable` to deprecated field list and lint rules
- Claude Code: add skill-builder support (SKILL_AUTHORING constant, INTENT_MODE routing, `load-skill-builder` process)

## Test plan
- [x] `python tools/check_versions.py` — OK: version=1.1.16
- [x] `python tools/sync_payload.py` — payloads synced
- [x] `python tools/check_skill_links.py` — no broken links
- [x] `npm test --prefix packages/aps-cli-node` — 45/45 passing
- [x] `cd packages/aps-cli-py && pytest -q tests` — 49/49 passing
- [ ] CI version consistency check