### PR TITLE
feat(platforms): add subagent architecture support to adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ skill/
         gui-component-spec-v1.0.0.example.md GUI component vocabulary and format contract
     guides/
       skill-authoring-v1.0.0.guide.md Skill authoring reference for humans and agents
+      subagent-architecture-v1.0.0.guide.md Cross-platform coordinator and worker authoring guide
     platforms/
       claude-code/
         adaptor.md Platform adapter (single source of truth)
@@ -157,10 +158,10 @@ SKILL_FOLDERS_DESC: TEXT<<
 The `references/` folder contains the normative APS v1.0 specification documents (00-07) that define the authoritative rules for prompt structure, vocabulary, linting, agentic control, schemas, grammar, logging/privacy, and error taxonomy.
 The `assets/` folder contains reusable templates and example components organized into `constants/`, `formats/`, and `composites/` subfolders that can be used when building APS-compliant prompts. Composites bundle tightly coupled `<constants>` and `<formats>` in a single file where the format contract references the constants as its type vocabulary.
 The `processes/` folder contains executable APS process documents that encode skill-specific workflows. Each process file is a full 7-section APS document loaded by agents on demand. This is a skill capability, not a fourth APS layer.
-The `guides/` folder contains reference documents for human and agent consumption. Guides provide authoring guidance, best practices, and design patterns, and may use APS envelope format or prose markdown.
+The `guides/` folder contains reference documents for human and agent consumption. Guides provide authoring guidance, best practices, design patterns, and cross-platform coordinator/worker interface rules, and may use APS envelope format or prose markdown.
 The `_template/` folder contains a minimal skill skeleton used to scaffold new skills. It ships with the payload after `aps init` and includes a stub SKILL.md with placeholder frontmatter plus empty directories for references, assets, processes, scripts, and guides.
 The `scripts/` folder is currently empty (reserved placeholder) for future automation scripts related to skill development.
-The `platforms/` folder contains non-normative platform adapters that describe platform-specific differences (file discovery, frontmatter, tool availability) without changing the core APS spec. The `claude-code/` adapter (used with `--platform claude-code`) is particularly important for Claude Code CLI users, alongside `opencode/` and `vscode-copilot/` adapters plus templates for creating new adapters.
+The `platforms/` folder contains non-normative platform adapters that describe platform-specific differences (file discovery, frontmatter, tool availability, subagent depth policy, and coordinator/worker wiring) without changing the core APS spec. The `claude-code/` adapter (used with `--platform claude-code`) is particularly important for Claude Code CLI users, alongside `opencode/` and `vscode-copilot/` adapters plus templates for creating new adapters.
 >>
 
 NODE_CLI_USAGE: TEXT<<

--- a/packages/aps-cli-node/test/platform_adaptor_conformance.test.ts
+++ b/packages/aps-cli-node/test/platform_adaptor_conformance.test.ts
@@ -69,3 +69,30 @@ test('AGENT_VERSIONING parses as JSON when present', async () => {
     assert.ok(Array.isArray(templates), `platforms/${dirName} AGENT_VERSIONING.templates is not an array`);
   }
 });
+
+test('each platform adaptor defines SUBAGENT_AUTHORING_GUIDE when subagent guidance is supported', async () => {
+  if (!(await pathExists(PLATFORMS_DIR))) return;
+
+  const dirs = await listPlatformDirs();
+  for (const dirName of dirs) {
+    const adaptorPath = path.join(PLATFORMS_DIR, dirName, 'adaptor.md');
+    const raw = await fs.readFile(adaptorPath, 'utf8');
+    const data = parseAdaptorMdString(raw);
+
+    assert.ok(getString(data.constants, 'SUBAGENT_AUTHORING_GUIDE', '').trim(), `platforms/${dirName} missing SUBAGENT_AUTHORING_GUIDE`);
+  }
+});
+
+test('SUBAGENT_ARCHITECTURE parses as an object when present', async () => {
+  if (!(await pathExists(PLATFORMS_DIR))) return;
+
+  const dirs = await listPlatformDirs();
+  for (const dirName of dirs) {
+    const adaptorPath = path.join(PLATFORMS_DIR, dirName, 'adaptor.md');
+    const raw = await fs.readFile(adaptorPath, 'utf8');
+    const data = parseAdaptorMdString(raw);
+
+    const v = data.constants['SUBAGENT_ARCHITECTURE'];
+    assert.ok(typeof v === 'object' && v !== null && !Array.isArray(v), `platforms/${dirName} SUBAGENT_ARCHITECTURE is not an object`);
+  }
+});

--- a/packages/aps-cli-py/tests/test_platform_manifest_fileconventions.py
+++ b/packages/aps-cli-py/tests/test_platform_manifest_fileconventions.py
@@ -68,3 +68,22 @@ def test_agent_versioning_is_valid_json_when_present():
         assert isinstance(av, dict), f"AGENT_VERSIONING must be an object in {platform.name}"
         templates = av.get("templates")
         assert isinstance(templates, list), f"AGENT_VERSIONING.templates must be a list in {platform.name}"
+
+def test_subagent_authoring_guide_is_present():
+    if not PLATFORMS_DIR.exists():
+        return
+
+    for platform in _platform_dirs():
+        data = parse_adaptor_md(platform / "adaptor.md")
+        guide = data.constants.get("SUBAGENT_AUTHORING_GUIDE")
+        assert isinstance(guide, str) and guide.strip(), f"Missing SUBAGENT_AUTHORING_GUIDE in {platform.name}"
+
+
+def test_subagent_architecture_is_valid_json_object():
+    if not PLATFORMS_DIR.exists():
+        return
+
+    for platform in _platform_dirs():
+        data = parse_adaptor_md(platform / "adaptor.md")
+        arch = data.constants.get("SUBAGENT_ARCHITECTURE")
+        assert isinstance(arch, dict), f"SUBAGENT_ARCHITECTURE must be an object in {platform.name}"

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   co_authors: "Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
   framework_revision: "1.1.17"
-  last_updated: "2026-02-18"
+  last_updated: "2026-03-12"
 ---
 
 # Agnostic Prompt Standard (APS) v1.0 — Skill Entry
@@ -59,6 +59,8 @@ This `SKILL.md` is the **entrypoint** for the Agnostic Prompt Standard (APS) v1.
   - `build-skill.md` — process for building new APS-compliant skills.
 - `guides/` — reference documents for humans and agents.
   - `skill-authoring-v1.0.0.guide.md` — skill authoring reference.
+  - `mcp-tool-bridge-v1.0.0.guide.md` — MCP tool bridge integration guide.
+  - `subagent-architecture-v1.0.0.guide.md` — cross-platform subagent architecture and interface mapping guide.
 - `platforms/` — **non-normative** platform adapters. Each platform has a single `adaptor.md` file.
   - `README.md` — platforms overview and contract.
   - `_template/` — skeleton for new platform adapters.
@@ -77,9 +79,11 @@ This `SKILL.md` is the **entrypoint** for the Agnostic Prompt Standard (APS) v1.
 
 ## Platform adapters
 
-Platform-specific details (file discovery, frontmatter dialects, tool naming) are documented in `platforms/`.
+Platform-specific details (file discovery, frontmatter dialects, tool naming, and coordinator/worker orchestration) are documented in `platforms/`.
 
 → See [platforms/README.md](platforms/README.md) for overview and how to add new adapters.
+
+→ See [guides/subagent-architecture-v1.0.0.guide.md](guides/subagent-architecture-v1.0.0.guide.md) for portable coordinator/worker authoring guidance.
 
 ### VS Code + GitHub Copilot
 

--- a/skill/agnostic-prompt-standard/guides/subagent-architecture-v1.0.0.guide.md
+++ b/skill/agnostic-prompt-standard/guides/subagent-architecture-v1.0.0.guide.md
@@ -1,0 +1,146 @@
+<instructions>
+You MUST load this guide before you author coordinator and worker agents.
+You MUST model portable multi-agent systems as one coordinator and one or more leaf workers.
+You MUST define the worker <input> block as the public request contract into the worker.
+You MUST mirror each worker <input> field in the caller dispatch process arguments.
+You MUST define a worker response contract in <formats> and capture it in the caller.
+You MUST keep platform-specific invocation syntax inside the caller dispatch layer only.
+You MUST use explicit allowlists for worker selection and tool access.
+You MUST keep worker results task-bounded, typed, and brief.
+You SHOULD use handoffs instead of nested worker spawning when a platform supports handoffs.
+You SHOULD treat undocumented nested delegation as unsupported for portable APS authoring.
+You MUST treat Claude Code workers as leaf workers.
+You SHOULD treat VS Code Copilot and OpenCode workers as leaf workers for portable APS authoring.
+</instructions>
+
+<constants>
+GUIDE_VERSION: "1.0.0"
+
+PLATFORM_CAPABILITY_MATRIX: CSV<<
+platform,coordinator_role,worker_role,documented_depth_policy,invocation_surface,notes
+claude-code,main-thread agent only,markdown subagent,depth-1-only,Agent,"Workers cannot spawn workers."
+vscode-copilot,main chat agent or prompt,subagent or custom agent worker,portable-depth-1,agent/runSubagent,"Custom-agent subagents are experimental and nested delegation is not documented."
+opencode,primary agent,mode=subagent worker,portable-depth-1,Task,"Primary/subagent roles are documented and nested delegation is not documented."
+generic,host-defined or manual APS coordinator,host-defined or external worker,host-defined,host-defined,"Use explicit APS dispatch processes when host behavior is unclear."
+>>
+
+REQUEST_INTERFACE_RULES: TEXT<<
+1. The worker <input> block is the public interface into the worker.
+2. The caller dispatch process MUST accept the same fields, names, and meanings.
+3. If a platform needs renamed fields, keep the rename in the dispatch layer only.
+4. Do not hide required worker inputs inside free-form prompt text.
+5. Keep request types stable across platforms.
+>>
+
+RESPONSE_INTERFACE_RULES: TEXT<<
+1. The worker MUST return a typed result that matches a <format> contract.
+2. The caller MUST capture the worker result before the next step starts.
+3. Keep summaries brief and task-bounded.
+4. Do not leak platform-only metadata unless the caller explicitly asks for it.
+>>
+
+PORTABLE_PATTERNS: JSON<<
+{
+  "coordinator_worker": {
+    "description": "One coordinator dispatches one worker and integrates the worker result.",
+    "best_for": ["single specialty task", "strong contract boundaries"]
+  },
+  "fan_out_review": {
+    "description": "One coordinator dispatches multiple leaf workers in parallel and then compares typed results.",
+    "best_for": ["research", "review", "verification"]
+  },
+  "sequential_handoff": {
+    "description": "One worker finishes, returns a typed result, and the coordinator hands off the next step to a different worker.",
+    "best_for": ["plan -> implement", "implement -> review"]
+  }
+}
+>>
+
+ANTI_PATTERNS: TEXT<<
+- Worker-to-worker recursion without a documented host contract.
+- Free-form worker prompts with hidden required fields.
+- Caller processes that rename or reshape worker inputs in multiple places.
+- Worker outputs that mix summary text, hidden state, and untyped data.
+- Broad tool access for narrow workers.
+>>
+
+APS_INTERFACE_EXAMPLE: TEXT<<
+Worker contract:
+<input>
+TICKET_ID: String
+TARGET_PATHS: String[]
+</input>
+
+Caller dispatch process:
+<process id="dispatch-review" name="Dispatch review" args="TICKET_ID: String, TARGET_PATHS: String[]">
+USE `Agent` where: description="Review the requested files", prompt="Review the requested files", worker="reviewer"
+SET WORKER_REQUEST := { TICKET_ID: TICKET_ID, TARGET_PATHS: TARGET_PATHS }
+CAPTURE REVIEW_RESULT from `reviewer`
+RETURN: REVIEW_RESULT
+</process>
+
+Rule:
+- The caller args are the same interface as the worker input.
+- The caller is responsible for the platform-specific call surface.
+- The worker returns a typed result that the caller captures.
+>>
+
+BIDIRECTIONAL_CONTRACT_RULE: TEXT<<
+Request flow: caller process args -> worker <input>.
+Response flow: worker <format> result -> caller capture variables.
+The contract is bidirectional only when the caller defines both mappings explicitly.
+>>
+</constants>
+
+<formats>
+<format id="SUBAGENT_ARCHITECTURE_SPEC_V1" name="Subagent Architecture Spec" purpose="Describe a coordinator plus worker architecture with explicit request and response contracts.">
+# Subagent Architecture Spec: <ARCHITECTURE_NAME>
+
+## Coordinator
+- Role: <COORDINATOR_ROLE>
+- Dispatch surface: <DISPATCH_SURFACE>
+- Depth policy: <DEPTH_POLICY>
+
+## Workers
+| Worker | Role | Input contract | Output contract | Allowed tools | Notes |
+|--------|------|----------------|-----------------|---------------|-------|
+| <WORKER_NAME> | <WORKER_ROLE> | <INPUT_CONTRACT_ID> | <OUTPUT_CONTRACT_ID> | <ALLOWED_TOOLS> | <WORKER_NOTES> |
+
+## Request and response mapping
+<REQUEST_RESPONSE_MAP>
+
+## Failure policy
+<FAILURE_POLICY>
+
+WHERE:
+- <ALLOWED_TOOLS> is String; comma-separated logical or host tool ids allowed for the worker.
+- <ARCHITECTURE_NAME> is String; descriptive name for the coordinator/worker design.
+- <COORDINATOR_ROLE> is String; the coordinator responsibility statement.
+- <DEPTH_POLICY> is String; one of depth-1-only, portable-depth-1, host-defined.
+- <DISPATCH_SURFACE> is String; host invocation surface such as Agent, agent/runSubagent, Task, or manual APS process.
+- <FAILURE_POLICY> is Markdown; what the coordinator does when a worker fails, times out, or returns invalid data.
+- <INPUT_CONTRACT_ID> is String; id or label of the worker request contract.
+- <OUTPUT_CONTRACT_ID> is String; id or label of the worker response contract.
+- <REQUEST_RESPONSE_MAP> is Markdown; explicit mapping from caller args to worker input and from worker result to caller capture.
+- <WORKER_NAME> is String; worker identifier.
+- <WORKER_NOTES> is String; short notes about visibility, allowlists, or platform limits.
+- <WORKER_ROLE> is String; worker responsibility statement.
+</format>
+
+<format id="SUBAGENT_CONTRACT_CHECKLIST_V1" name="Subagent Contract Checklist" purpose="Review checklist for portable coordinator/worker authoring.">
+# Subagent Contract Checklist
+
+- [ ] The coordinator is the single dispatch owner.
+- [ ] Each worker has an explicit APS <input> contract.
+- [ ] Each caller dispatch process mirrors the worker input fields one-for-one.
+- [ ] Each worker returns a typed <format> result.
+- [ ] The caller captures the worker result before the next step starts.
+- [ ] Nested delegation is either documented by the host or avoided.
+- [ ] Worker tool access uses least privilege.
+- [ ] Worker visibility and allowlists are explicit.
+- [ ] Platform-only routing details stay outside the portable contract.
+
+WHERE:
+- This checklist is a fixed review format with no placeholders.
+</format>
+</formats>

--- a/skill/agnostic-prompt-standard/platforms/README.md
+++ b/skill/agnostic-prompt-standard/platforms/README.md
@@ -2,10 +2,11 @@
 
 APS is designed to be **platform-agnostic**, but real hosts (IDEs, agent runtimes, CI bots) differ in:
 
-- File discovery conventions (where prompts/agents/skills live)
-- YAML frontmatter dialects (which fields exist, required/optional)
+- File discovery conventions (where prompts, agents, and skills live)
+- YAML frontmatter dialects (which fields exist and which are optional)
 - Tool availability, naming, and approval UX
 - Safety constraints (auto-approve settings, restricted file paths)
+- Multi-agent orchestration surfaces (how a coordinator invokes workers)
 
 This folder contains **platform adapters** that describe those differences *without changing the APS v1.0 spec*.
 
@@ -23,32 +24,50 @@ platforms/
     templates/                    # optional installable agent files
       .claude/agents/             # (claude-code) or
       .github/agents/             # (vscode-copilot)
-      # no templates/              # (generic / external tools)
+      # no templates/             # (generic / external tools)
 ```
 
 The `adaptor.md` file contains three APS sections:
 
 1. `<instructions>` — platform-specific generation instructions
-2. `<constants>` — all metadata: platform ID, detection markers, file conventions, tool registries, agent versioning
+2. `<constants>` — metadata such as platform ID, detection markers, file conventions, subagent depth policy, and tool registries
 3. `<formats>` — frontmatter and output format contracts
 
 The `generic/` adapter is the neutral option for tool-agnostic or external-tool-only workflows.
 It has no detection markers and no installable templates.
 
+## Subagent authoring contract
+
+Adapters should document the host-specific orchestration surface for coordinator and worker authoring.
+At minimum, an adapter should state:
+
+- which artifact type is the coordinator
+- which artifact type is the worker
+- which tool or surface invokes the worker
+- the documented depth policy
+- how APS worker `<input>` maps to caller dispatch args
+- how worker outputs are captured back into the caller
+
+If nested delegation is undocumented, the adapter should default to **portable depth-1 authoring**.
+That means one coordinator dispatches leaf workers, and all platform-specific routing stays in the caller dispatch layer.
+
+→ See [`guides/subagent-architecture-v1.0.0.guide.md`](../guides/subagent-architecture-v1.0.0.guide.md)
+
 ## Add a new platform adapter
 
 1. Copy `platforms/_template/` to `platforms/<platform-id>/`
 2. Fill in `adaptor.md` with platform-specific constants and formats
-3. Optionally add a `templates/` directory with installable agent files
-4. Do **not** change `references/` unless you are intentionally publishing an APS spec revision
+3. Document coordinator/worker roles, dispatch surface, and depth policy
+4. Optionally add a `templates/` directory with installable agent files
+5. Do **not** change `references/` unless you are intentionally publishing an APS spec revision
 
 ## Contract
 
 - Anything under `references/` is **normative** APS.
-- Anything under `platforms/` is **non-normative** (documentation/templates/mappings only).
+- Anything under `platforms/` is **non-normative** (documentation, templates, and mappings only).
 - Adapters should prefer **mapping + configuration** over rewriting APS core rules.
 
-## Scope and Philosophy
+## Scope and philosophy
 
 Adapters are intended to **map** the APS standard to a host platform. They are **not** project generators.
 We do not provide generic project scaffolding (like `settings.json` or root `CLAUDE.md` templates).

--- a/skill/agnostic-prompt-standard/platforms/_template/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/_template/adaptor.md
@@ -1,16 +1,33 @@
 <instructions>
 Replace this section with platform-specific generation instructions.
 Describe tool naming conventions, file locations, frontmatter rules, and MCP config surfaces when applicable.
+Document how a coordinator invokes workers on this host.
+Map each worker APS `<input>` field to the caller dispatch args.
+If nested delegation is undocumented, default to portable depth-1 authoring.
 </instructions>
 
 <constants>
 PLATFORM_ID: "your-platform-id"
 DISPLAY_NAME: "Your Platform"
-ADAPTER_VERSION: "0.1.0"
+ADAPTER_VERSION: "0.2.0"
 LAST_UPDATED: "YYYY-MM-DD"
 
-INSTRUCTION_FILE_PATHS: [".github/copilot-instructions.md"]
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
 
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Describe the coordinator artifact or surface.",
+  "worker_role": "Describe the worker artifact or surface.",
+  "depth_policy": "host-defined-or-portable-depth-1",
+  "documented_limit": "Describe documented nesting limits or say not documented.",
+  "invocation_surface": "Describe the tool, command, handoff, or API that invokes the worker.",
+  "request_contract_rule": "Worker <input> is the public request interface and the caller mirrors it in dispatch args.",
+  "response_contract_rule": "Worker returns a typed result and the caller captures it before the next step.",
+  "portability_rule": "Keep host-specific routing in the caller dispatch layer only."
+}
+>>
+
+INSTRUCTION_FILE_PATHS: [".github/copilot-instructions.md"]
 DETECTION_MARKERS: [".github/agents/", "path/to/marker.file"]
 MCP_CONFIG_PATHS: []
 

--- a/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
@@ -9,13 +9,48 @@ Hooks execute shell commands at lifecycle events and are configured in .claude/s
 Permissions use Tool(specifier) with allow/deny/ask arrays in .claude/settings.json.
 Claude Code stores project-scoped MCP servers in .mcp.json at the project root and user/local MCP servers in ~/.claude.json.
 Tools in frontmatter are comma-separated strings (e.g., tools: Read, Write, Edit).
+You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring coordinator or worker agents.
+You MUST treat `.claude/agents/*.md` worker agents as leaf workers because Claude subagents cannot spawn subagents.
+You MUST map worker APS `<input>` fields to caller dispatch process args one-for-one.
 </instructions>
 
 <constants>
 PLATFORM_ID: "claude-code"
 DISPLAY_NAME: "Claude Code CLI"
-ADAPTER_VERSION: "2.0.0"
-LAST_UPDATED: "2026-02-19"
+ADAPTER_VERSION: "2.1.0"
+LAST_UPDATED: "2026-03-12"
+
+ARTIFACT_TYPES: CSV<<
+type,file_pattern,config_format
+agent,.claude/agents/*.md,CC_AGENT_FRONTMATTER_V1
+rules,.claude/rules/*.md,CC_RULES_FRONTMATTER_V1
+hooks,.claude/settings.json,CC_HOOKS_CONFIG_V1
+permissions,.claude/settings.json,CC_PERMISSIONS_CONFIG_V1
+>>
+
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
+
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Main-thread agent only",
+  "worker_role": "Markdown-defined subagent in .claude/agents/*.md",
+  "depth_policy": "depth-1-only",
+  "documented_limit": "Subagents cannot spawn other subagents.",
+  "invocation_tool": "Agent",
+  "invocation_aliases": ["Task"],
+  "allowlist_surface": "tools: Agent(worker, reviewer)",
+  "definition_paths": ["./.claude/agents/*.md", "~/.claude/agents/*.md"],
+  "defaults": {
+    "model": "inherit when omitted",
+    "tools": "inherit all tools when omitted",
+    "skills": "do not inherit; list explicitly",
+    "permissionMode": "inherits current permission context unless overridden"
+  },
+  "request_contract_rule": "Author each worker <input> as the public request interface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "Return a typed result and capture it in the caller before the next step.",
+  "portability_rule": "Author Claude workers as leaf workers. Keep all platform-specific Agent wiring in the caller dispatch layer."
+}
+>>
 
 INSTRUCTION_FILE_PATHS: ["./CLAUDE.md", "./.claude/CLAUDE.md", "./.claude/rules/*.md", "./CLAUDE.local.md", "~/.claude/CLAUDE.md", "~/.claude/rules/*.md"]
 AGENT_FILE_PATHS: ["./.claude/agents/*.md", "~/.claude/agents/*.md"]
@@ -25,13 +60,17 @@ MEMORY_LOAD_ORDER: [INSTRUCTION_FILE_PATHS, AGENT_FILE_PATHS, MCP_CONFIG_PATHS, 
 
 DETECTION_MARKERS: [".claude", "CLAUDE.md", "CLAUDE.local.md", ".mcp.json", ".claude/settings.json", ".claude/agents", ".claude/rules"]
 
+CONFIG_SCOPES: ["managed", "user", "project", "local"]
+SUBAGENT_MEMORY_SCOPES: ["user", "project", "local"]
+SUBAGENT_RUN_MODES: ["foreground", "background"]
+
 MEMORY_LEVEL_ENTERPRISE: "Managed by organization admins."
 MEMORY_LEVEL_PROJECT: ["./CLAUDE.md", "./.claude/CLAUDE.md"]
 MEMORY_LEVEL_RULES: ["./.claude/rules/*.md"]
 MEMORY_LEVEL_USER: ["~/.claude/CLAUDE.md", "./CLAUDE.local.md"]
 MEMORY_OVERRIDE_ORDER: [MEMORY_LEVEL_ENTERPRISE, MEMORY_LEVEL_PROJECT, MEMORY_LEVEL_RULES, MEMORY_LEVEL_USER]
 
-HOOK_EVENTS: ["PreToolUse", "PostToolUse", "PermissionRequest", "Stop", "SubagentStop", "UserPromptSubmit", "SessionStart", "SessionEnd", "PreCompact", "Notification"]
+HOOK_EVENTS: ["PreToolUse", "PostToolUse", "PermissionRequest", "Stop", "SubagentStart", "SubagentStop", "UserPromptSubmit", "SessionStart", "SessionEnd", "PreCompact", "Notification"]
 HOOK_CONFIG_PATH: ".claude/settings.json"
 
 TOOL_NAMING_STYLE: "PascalCase"
@@ -41,33 +80,34 @@ TOOL_FRONTMATTER_SYNTAX: "comma-separated strings (e.g., tools: Read, Write, Edi
 
 TOOLS: CSV<<
 name,toolset,risk,side_effects,description,params
-Read,filesystem,low,reads,"Read file contents. Supports text/images/PDFs/notebooks.","[file_path:string:required, offset:integer:optional, limit:integer:optional, pages:string:optional]"
-Write,filesystem,medium,writes,"Create or overwrite files. Read first if exists. Prefer Edit.","[file_path:string:required, content:string:required]"
-Edit,filesystem,medium,writes,"Exact string replacement. old_string must be unique.","[file_path:string:required, old_string:string:required, new_string:string:required, replace_all:boolean:optional]"
-Glob,filesystem,low,reads,"Find files by glob pattern. Returns paths sorted by modification time.","[pattern:string:required, path:string:optional]"
-Grep,filesystem,low,reads,"Search file contents using regex (ripgrep). Use glob/type for filtering.","[pattern:string:required, path:string:optional, glob:string:optional, type:string:optional, output_mode:enum(content|files_with_matches|count):optional]"
-NotebookEdit,filesystem,medium,writes,"Replace/insert/delete cells in Jupyter notebooks.","[notebook_path:string:required, new_source:string:required, cell_id:string:optional, cell_type:enum(code|markdown):optional, edit_mode:enum(replace|insert|delete):optional]"
-Bash,execution,high,executes,"Execute bash commands. Use for git/npm/docker. Avoid for file ops.","[command:string:required, description:string:optional, timeout:integer:optional, run_in_background:boolean:optional]"
-Task,execution,medium,mixed,"Launch specialized subagents for complex multi-step tasks.","[description:string:required, prompt:string:required, subagent_type:string:required, model:enum(sonnet|opus|haiku):optional, run_in_background:boolean:optional, max_turns:integer:optional]"
-TaskOutput,execution,low,reads,"Retrieve output from running or completed background task.","[task_id:string:required, block:boolean:optional, timeout:integer:optional]"
+Read,filesystem,low,reads,"Read file contents. Supports text, images, PDFs, and notebooks.","[file_path:string:required, offset:integer:optional, limit:integer:optional, pages:string:optional]"
+Write,filesystem,medium,writes,"Create or overwrite files. Read first if the file exists. Prefer Edit for localized changes.","[file_path:string:required, content:string:required]"
+Edit,filesystem,medium,writes,"Exact string replacement. old_string must be unique unless replace_all is true.","[file_path:string:required, old_string:string:required, new_string:string:required, replace_all:boolean:optional]"
+Glob,filesystem,low,reads,"Find files by glob pattern.","[pattern:string:required, path:string:optional]"
+Grep,filesystem,low,reads,"Search file contents using regex.","[pattern:string:required, path:string:optional, glob:string:optional, type:string:optional, output_mode:enum(content|files_with_matches|count):optional]"
+NotebookEdit,filesystem,medium,writes,"Replace, insert, or delete notebook cells.","[notebook_path:string:required, new_source:string:required, cell_id:string:optional, cell_type:enum(code|markdown):optional, edit_mode:enum(replace|insert|delete):optional]"
+Bash,execution,high,executes,"Execute bash commands. Use for git, npm, docker, and test runs.","[command:string:required, description:string:optional, timeout:integer:optional, run_in_background:boolean:optional]"
+Agent,execution,medium,mixed,"Launch specialized subagents from a main-thread agent.","[description:string:required, prompt:string:required, subagent_type:string:required, model:enum(sonnet|opus|haiku|inherit):optional, run_in_background:boolean:optional, max_turns:integer:optional]"
+Task,execution,medium,mixed,"Deprecated alias for Agent.","[description:string:required, prompt:string:required, subagent_type:string:required, model:enum(sonnet|opus|haiku|inherit):optional, run_in_background:boolean:optional, max_turns:integer:optional]"
+TaskOutput,execution,low,reads,"Retrieve output from a running or completed background task.","[task_id:string:required, block:boolean:optional, timeout:integer:optional]"
 TaskStop,execution,low,executes,"Stop a running background task by ID.","[task_id:string:required]"
 TaskCreate,execution,low,none,"Create a new task in the structured task list.","[subject:string:required, description:string:required, activeForm:string:optional]"
-TaskUpdate,execution,low,none,"Update task status/details/dependencies.","[taskId:string:required, status:enum(pending|in_progress|completed|deleted):optional, subject:string:optional, description:string:optional]"
-TaskList,execution,low,reads,"List all tasks with status and dependencies.",""
-TaskGet,execution,low,reads,"Get full details of a specific task by ID.","[taskId:string:required]"
-TodoWrite,execution,low,none,"Create and manage structured task/todo items for tracking session progress.","[subject:string:required, description:string:required, activeForm:string:optional]"
-MCPSearch,execution,low,reads,"Search for and load MCP tools. Requires MCP servers configured.",""
-WebFetch,web,medium,network,"Fetch URL content and process with prompt. 15-min cache. Fails for auth URLs.","[url:string:required, prompt:string:required]"
-WebSearch,web,medium,network,"Search the web. Must include Sources section with URLs.","[query:string:required, allowed_domains:array:optional, blocked_domains:array:optional]"
-AskUserQuestion,interaction,low,none,"Ask user questions. 1-4 questions with 2-4 options each.","[questions:array:required]"
-Skill,skills,medium,mixed,"Execute a skill (slash command) within the conversation.","[skill:string:required, args:string:optional]"
-EnterPlanMode,planning,low,none,"Transition to plan mode for implementation approaches.",""
-ExitPlanMode,planning,low,none,"Signal plan completion and request user approval.","[allowedPrompts:array:optional, pushToRemote:boolean:optional]"
-LSP,code_intelligence,low,reads,"Code intelligence via Language Server Protocol. IDE-only.",""
+TaskUpdate,execution,low,none,"Update task status, details, or dependencies.","[taskId:string:required, status:enum(pending|in_progress|completed|deleted):optional, subject:string:optional, description:string:optional]"
+TaskList,execution,low,reads,"List all structured tasks.",""
+TaskGet,execution,low,reads,"Get full details for a structured task.","[taskId:string:required]"
+TodoWrite,execution,low,none,"Create and manage structured todo items for session progress.","[subject:string:required, description:string:required, activeForm:string:optional]"
+MCPSearch,execution,low,reads,"Search for and load MCP tools.",""
+WebFetch,web,medium,network,"Fetch URL content and process it with a prompt.","[url:string:required, prompt:string:required]"
+WebSearch,web,medium,network,"Search the web.","[query:string:required, allowed_domains:array:optional, blocked_domains:array:optional]"
+AskUserQuestion,interaction,low,none,"Ask the user structured questions.","[questions:array:required]"
+Skill,skills,medium,mixed,"Execute a skill within the conversation.","[skill:string:required, args:string:optional]"
+EnterPlanMode,planning,low,none,"Transition to plan mode.",""
+ExitPlanMode,planning,low,none,"Signal plan completion and request approval.","[allowedPrompts:array:optional, pushToRemote:boolean:optional]"
+LSP,code_intelligence,low,reads,"Code intelligence via Language Server Protocol.",""
 >>
 
-RECOMMENDED_PLANNER_TOOLS: ["Read", "Glob", "Grep", "WebFetch", "WebSearch", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet", "AskUserQuestion", "Task"]
-RECOMMENDED_IMPLEMENTER_TOOLS: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet", "Task", "NotebookEdit"]
+RECOMMENDED_PLANNER_TOOLS: ["Read", "Glob", "Grep", "WebFetch", "WebSearch", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet", "AskUserQuestion", "Agent"]
+RECOMMENDED_IMPLEMENTER_TOOLS: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "TaskCreate", "TaskUpdate", "TaskList", "TaskGet", "Agent", "NotebookEdit"]
 
 PERMISSION_MODES: ["default", "acceptEdits", "dontAsk", "bypassPermissions", "plan"]
 AGENT_MODELS: ["sonnet", "opus", "haiku", "inherit"]
@@ -95,24 +135,30 @@ SKILL_AUTHORING_RESOURCES: JSON<<
 }
 >>
 
-DOCS_MEMORY_URL: "https://docs.anthropic.com/en/docs/claude-code/memory"
-DOCS_SETTINGS_URL: "https://docs.anthropic.com/en/docs/claude-code/settings"
-DOCS_HOOKS_URL: "https://docs.anthropic.com/en/docs/claude-code/hooks"
-DOCS_MCP_URL: "https://docs.anthropic.com/en/docs/claude-code/mcp"
-DOCS_TOOLS_URL: "https://docs.anthropic.com/en/docs/claude-code/cli-reference"
-DOCS_SUBAGENTS_URL: "https://docs.anthropic.com/en/docs/claude-code/sub-agents"
+DOCS_MEMORY_URL: "https://code.claude.com/docs/en/memory"
+DOCS_SETTINGS_URL: "https://code.claude.com/docs/en/settings"
+DOCS_HOOKS_URL: "https://code.claude.com/docs/en/hooks"
+DOCS_MCP_URL: "https://code.claude.com/docs/en/mcp"
+DOCS_TOOLS_URL: "https://code.claude.com/docs/en/cli-reference"
+DOCS_SUBAGENTS_URL: "https://code.claude.com/docs/en/sub-agents"
 </constants>
 
 <formats>
-<format id="CC_AGENT_FRONTMATTER_V1" name="Claude Code Agent Frontmatter" purpose="YAML frontmatter contract for .claude/agents/*.md subagent files.">
+<format id="CC_AGENT_FRONTMATTER_V1" name="Claude Code Agent Frontmatter" purpose="YAML frontmatter contract for coordinator or worker files in .claude/agents/*.md.">
 ---
 name: <AGENT_NAME>
 description: "<AGENT_DESCRIPTION>"
-model: <MODEL>
 tools: <TOOLS_LIST>
 disallowedTools: <DISALLOWED_TOOLS>
+model: <MODEL>
 permissionMode: <PERMISSION_MODE>
-skills: <SKILLS>
+maxTurns: <MAX_TURNS>
+skills:
+  - <SKILL_NAME>
+mcpServers:
+  - <MCP_SERVER_NAME>
+memory: <MEMORY_SCOPE>
+background: <BACKGROUND>
 hooks:
   <HOOK_EVENT>:
     - matcher: "<MATCHER_PATTERN>"
@@ -122,16 +168,20 @@ hooks:
 ---
 
 WHERE:
-- <AGENT_NAME> is String; regex: ^[a-z][a-z0-9-]{1,63}$; unique across all loaded subagents.
-- <AGENT_DESCRIPTION> is String; describes what the subagent does and when to invoke it.
-- <MODEL> is one of AGENT_MODELS; default inherit; omit to use default.
-- <TOOLS_LIST> is String; comma-separated names from TOOLS; omit if no allowlist needed.
-- <DISALLOWED_TOOLS> is String; comma-separated names from TOOLS; omit if no denylist needed.
-- <PERMISSION_MODE> is one of PERMISSION_MODES; default default; omit to use default.
-- <SKILLS> is String; comma-separated skill names; omit if no skills needed.
-- <HOOK_EVENT> is one of: "PreToolUse", "PostToolUse", "Stop"; subset of HOOK_EVENTS.
-- <MATCHER_PATTERN> is String; tool name to match (e.g., "Bash", "Write").
+- <AGENT_DESCRIPTION> is String; single-line double-quoted string that says what the agent does and when to invoke it.
+- <AGENT_NAME> is String; regex: ^[a-z][a-z0-9-]{1,63}$; unique across all loaded agents.
+- <BACKGROUND> is Boolean; true to always run the worker as a background task.
+- <DISALLOWED_TOOLS> is String; comma-separated names from TOOLS; omit if no denylist is needed.
 - <HOOK_COMMAND> is String; shell command to execute; receives tool context via environment variables.
+- <HOOK_EVENT> is one of HOOK_EVENTS.
+- <MATCHER_PATTERN> is String; tool name or regex pattern to match.
+- <MAX_TURNS> is Integer; maximum number of agentic turns before the agent stops.
+- <MCP_SERVER_NAME> is String; preconfigured MCP server name; repeat or replace the list with inline server objects when needed.
+- <MEMORY_SCOPE> is one of SUBAGENT_MEMORY_SCOPES; omit if no persistent memory is needed.
+- <MODEL> is one of AGENT_MODELS; omit to inherit the parent model.
+- <PERMISSION_MODE> is one of PERMISSION_MODES; omit to inherit the current permission context.
+- <SKILL_NAME> is String; skill id to preload into the agent context; omit the list if no skills are needed.
+- <TOOLS_LIST> is String; comma-separated PascalCase names from TOOLS. For main-thread coordinators use `Agent` or `Agent(worker, reviewer)`. For leaf workers omit `Agent`.
 </format>
 
 <format id="CC_RULES_FRONTMATTER_V1" name="Claude Code Rules Frontmatter" purpose="YAML frontmatter contract for .claude/rules/*.md path-scoped rules.">
@@ -141,7 +191,7 @@ paths:
 ---
 
 WHERE:
-- <GLOB_PATTERN> is String; standard glob syntax (e.g., "src/**/*.ts", "**/*.test.ts", "docs/**/*.md"); ** for recursive matching, * for single directory.
+- <GLOB_PATTERN> is String; standard glob syntax such as "src/**/*.ts", "**/*.test.ts", or "docs/**/*.md".
 </format>
 
 <format id="CC_HOOKS_CONFIG_V1" name="Claude Code Hooks Config" purpose="JSON structure for hooks in .claude/settings.json.">
@@ -158,7 +208,7 @@ WHERE:
 
 WHERE:
 - <HOOK_EVENT> is one of HOOK_EVENTS.
-- <MATCHER_PATTERN> is String; tool name to match (e.g., "Bash"); omit matcher for unconditional hooks.
+- <MATCHER_PATTERN> is String; tool or agent matcher; omit matcher for unconditional hooks.
 - <HOOK_COMMAND> is String; shell command to execute at the lifecycle event.
 </format>
 
@@ -172,7 +222,7 @@ WHERE:
 }
 
 WHERE:
-- <TOOL_NAME> is String; exact tool name from TOOLS (e.g., "Read", "Glob", "Grep").
-- <TOOL_SPECIFIER> is String; tool name with optional argument restriction (e.g., "Bash(rm -rf *)").
+- <TOOL_NAME> is String; exact PascalCase tool name from TOOLS, for example "Read", "Glob", "Grep", or "Agent(worker)".
+- <TOOL_SPECIFIER> is String; tool name with optional argument restriction, for example "Bash(rm -rf *)" or "Agent(my-custom-agent)".
 </format>
 </formats>

--- a/skill/agnostic-prompt-standard/platforms/generic/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/generic/adaptor.md
@@ -1,5 +1,10 @@
 <instructions>
 Generate artifacts for tool-agnostic APS usage or for runtimes that use external tools only.
+You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring coordinator or worker contracts.
+You MUST keep the APS coordinator as the single dispatch owner unless the host documents nested delegation.
+You MUST define worker `<input>` as the interface into the worker and mirror it in the caller dispatch process.
+You MUST define worker `<format>` outputs and capture them in the caller before the next step.
+You MUST isolate host-specific tool or routing names in config files instead of APS process text.
 Use this adapter when a host has no stable native tool registry, when tools come only from MCP or an equivalent external declaration file, or when you want one neutral tool layer across hosts.
 Do not assume host-specific file names, frontmatter, or native tool naming.
 Declare external tools in `predefinedTools.json` with canonical APS tool ids.
@@ -9,17 +14,50 @@ If a host exposes decorated runtime names, map them with `config.json` ALIAS ent
 <constants>
 PLATFORM_ID: "generic"
 DISPLAY_NAME: "Generic / External Tools"
-ADAPTER_VERSION: "1.0.0"
-LAST_UPDATED: "2026-03-10"
+ADAPTER_VERSION: "1.1.0"
+LAST_UPDATED: "2026-03-12"
+
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
+
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Host-defined or manual APS coordinator",
+  "worker_role": "Host-defined, external, or user-mediated worker",
+  "depth_policy": "unknown-use-depth-1-by-default",
+  "invocation_surface": "host-defined",
+  "request_contract_rule": "Define the worker <input> as the public interface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "Define a typed worker result and capture it before the caller continues.",
+  "fallback_pattern": "If the host has no native subagent surface, model delegation as explicit APS processes or user-mediated steps."
+}
+>>
 
 INSTRUCTION_FILE_PATHS: []
 DETECTION_MARKERS: []
 MCP_CONFIG_PATHS: []
 TOOL_SOURCES: ["native", "mcp", "mixed", "none"]
+HOST_CAPABILITY_STATES: ["unknown", "depth-1", "nested", "manual"]
 EXTERNAL_TOOL_DECLARATION_FILES: ["predefinedTools.json", "config.json"]
 
 DOCS_MCP_URL: "https://modelcontextprotocol.io/specification/2025-06-18/schema"
 </constants>
 
 <formats>
+<format id="GENERIC_COORDINATOR_WORKER_MAP_V1" name="Generic Coordinator Worker Map" purpose="Document host-neutral worker routing and contract mapping.">
+# Generic Coordinator Worker Map
+
+| Worker | Input contract | Invocation surface | Output contract | Notes |
+|--------|----------------|--------------------|-----------------|-------|
+| <WORKER_NAME> | <INPUT_CONTRACT_ID> | <INVOCATION_SURFACE> | <OUTPUT_CONTRACT_ID> | <NOTES> |
+
+## Caller mapping
+<REQUEST_RESPONSE_MAP>
+
+WHERE:
+- <INPUT_CONTRACT_ID> is String; worker request contract id or label.
+- <INVOCATION_SURFACE> is String; host-defined invocation mechanism or `manual APS process`.
+- <NOTES> is String; routing, policy, or fallback notes.
+- <OUTPUT_CONTRACT_ID> is String; worker response contract id or label.
+- <REQUEST_RESPONSE_MAP> is Markdown; explicit mapping from caller args to worker input and from worker output to caller capture.
+- <WORKER_NAME> is String; worker identifier.
+</format>
 </formats>

--- a/skill/agnostic-prompt-standard/platforms/opencode/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/opencode/adaptor.md
@@ -1,26 +1,159 @@
 <instructions>
-Generate artifacts for the OpenCode agent runtime using the constants in this adapter.
-OpenCode uses AGENTS.md and JSONC configuration files.
-Configuration supports JSON with comments (JSONC).
-MCP servers are declared in the top-level mcp object of the OpenCode config file.
+Generate artifacts for the OpenCode agent runtime using the constants and format contracts in this adapter.
+You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring primary agents or subagents.
+You MUST treat `mode: primary` agents as coordinators and `mode: subagent` agents as workers.
+You SHOULD treat OpenCode workers as leaf workers for portable APS authoring because nested delegation is not documented.
+You MUST map worker APS `<input>` fields to caller dispatch process args one-for-one.
+You MUST keep host-specific `Task` and command `subtask` wiring in the caller dispatch layer.
 </instructions>
 
 <constants>
 PLATFORM_ID: "opencode"
 DISPLAY_NAME: "OpenCode"
-ADAPTER_VERSION: "2.0.0"
-LAST_UPDATED: "2026-02-19"
+ADAPTER_VERSION: "2.1.0"
+LAST_UPDATED: "2026-03-12"
+
+ARTIFACT_TYPES: CSV<<
+type,scope,file_pattern,config_format
+agent,project,.opencode/agents/*.md,OPENCODE_AGENT_FRONTMATTER_V1
+agent,user,~/.config/opencode/agents/*.md,OPENCODE_AGENT_FRONTMATTER_V1
+config,project,.opencode/opencode.json,OPENCODE_AGENT_CONFIG_JSON_V1
+config,project,.opencode/opencode.jsonc,OPENCODE_AGENT_CONFIG_JSON_V1
+config,project,opencode.json,OPENCODE_AGENT_CONFIG_JSON_V1
+config,project,opencode.jsonc,OPENCODE_AGENT_CONFIG_JSON_V1
+>>
+
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
+
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Primary agent",
+  "worker_role": "Subagent configured with mode: subagent",
+  "depth_policy": "portable-depth-1",
+  "documented_limit": "Primary and subagent roles are documented, but nested delegation is not documented.",
+  "invocation_tool": "Task",
+  "manual_invocation": "@mention",
+  "definition_paths": [".opencode/agents/*.md", "~/.config/opencode/agents/*.md"],
+  "allowlist_surface": "permission.task",
+  "visibility_surface": "hidden",
+  "mode_surface": "mode",
+  "defaults": {
+    "model": "subagent inherits the invoking primary model when omitted",
+    "todo_tools": "todoread and todowrite are disabled for subagents by default"
+  },
+  "request_contract_rule": "Define the worker <input> as the public request interface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "Return a typed or tightly bounded result and capture it in the primary process before the next step.",
+  "command_rule": "If a command targets a subagent it triggers a subagent invocation by default. Use subtask:true to force subagent invocation."
+}
+>>
 
 INSTRUCTION_FILE_PATHS: ["AGENTS.md", ".opencode/instructions.md"]
-CONFIG_FILE_PATHS: [".opencode/opencode.jsonc", ".opencode/opencode.json", "opencode.json", "opencode.jsonc", ".opencode.json"]
-MCP_CONFIG_PATHS: [".opencode/opencode.jsonc", ".opencode/opencode.json", "opencode.json", "opencode.jsonc", ".opencode.json"]
+AGENT_FILE_PATHS: [".opencode/agents/*.md", "~/.config/opencode/agents/*.md"]
+CONFIG_FILE_PATHS: [".opencode/opencode.json", ".opencode/opencode.jsonc", "opencode.json", "opencode.jsonc", ".opencode.json"]
+MCP_CONFIG_PATHS: [".opencode/opencode.json", ".opencode/opencode.jsonc", "opencode.json", "opencode.jsonc", ".opencode.json"]
+DETECTION_MARKERS: [".opencode", ".opencode/agents", ".opencode/opencode.json", ".opencode/opencode.jsonc", "opencode.json", "opencode.jsonc", ".opencode.json"]
 
-DETECTION_MARKERS: [".opencode", ".opencode/opencode.jsonc", ".opencode/opencode.json", "opencode.json", "opencode.jsonc", ".opencode.json"]
+AGENT_MODES: ["primary", "subagent", "all"]
+COMMAND_SUBTASK_RULE: "If a command sets agent to a subagent, it triggers subagent invocation by default. Use subtask:false to disable. Use subtask:true to force subagent invocation."
+SUBAGENT_TODO_DEFAULT: "todoread and todowrite are disabled for subagents by default."
 
 DOCS_OFFICIAL_URL: "https://opencode.ai/docs"
-DOCS_CONFIG_URL: "https://opencode.ai/docs/config"
+DOCS_AGENTS_URL: "https://opencode.ai/docs/agents/"
+DOCS_COMMANDS_URL: "https://opencode.ai/docs/commands/"
+DOCS_PERMISSIONS_URL: "https://opencode.ai/docs/permissions/"
+DOCS_TOOLS_URL: "https://opencode.ai/docs/tools/"
 DOCS_MCP_URL: "https://opencode.ai/docs/mcp-servers/"
 </constants>
 
 <formats>
+<format id="OPENCODE_AGENT_FRONTMATTER_V1" name="OpenCode Agent Frontmatter" purpose="YAML frontmatter contract for markdown agent files in .opencode/agents/*.md or ~/.config/opencode/agents/*.md.">
+---
+description: <DESCRIPTION>
+mode: <MODE>
+model: <MODEL>
+temperature: <TEMPERATURE>
+steps: <STEPS>
+tools:
+  <TOOL_NAME>: <TOOL_ENABLED>
+permission:
+  <PERMISSION_NAME>: <PERMISSION_VALUE>
+  task:
+    "<AGENT_GLOB>": <TASK_PERMISSION>
+hidden: <HIDDEN>
+disable: <DISABLE>
+---
+
+WHERE:
+- <AGENT_GLOB> is String; glob pattern matched against subagent names in permission.task.
+- <DESCRIPTION> is String; required description of what the agent does and when to use it.
+- <DISABLE> is Boolean; true to disable the agent.
+- <HIDDEN> is Boolean; only applicable to mode `subagent`; hides the worker from `@` autocomplete.
+- <MODE> is one of AGENT_MODES.
+- <MODEL> is String; provider/model-id. Omit it on workers to inherit the invoking primary model.
+- <PERMISSION_NAME> is String; permission key such as `edit`, `bash`, `webfetch`, `todoread`, or `todowrite`.
+- <PERMISSION_VALUE> is String; one of `allow`, `ask`, or `deny`.
+- <STEPS> is Integer; maximum number of agentic steps; prefer `steps` over the deprecated `maxSteps`.
+- <TASK_PERMISSION> is String; one of `allow`, `ask`, or `deny`.
+- <TEMPERATURE> is Number; typical range 0.0 to 1.0.
+- <TOOL_ENABLED> is Boolean; true or false.
+- <TOOL_NAME> is String; tool id or wildcard such as `write`, `edit`, `bash`, or `mymcp_*`.
+- The markdown filename becomes the agent name.
+</format>
+
+<format id="OPENCODE_AGENT_CONFIG_JSON_V1" name="OpenCode Agent Config JSON" purpose="JSON fragment for agent configuration in opencode.json or opencode.jsonc.">
+{
+  "agent": {
+    "<AGENT_NAME>": {
+      "description": "<DESCRIPTION>",
+      "mode": "<MODE>",
+      "model": "<MODEL>",
+      "steps": <STEPS>,
+      "tools": {
+        "<TOOL_NAME>": <TOOL_ENABLED>
+      },
+      "permission": {
+        "<PERMISSION_NAME>": "<PERMISSION_VALUE>",
+        "task": {
+          "<AGENT_GLOB>": "<TASK_PERMISSION>"
+        }
+      },
+      "hidden": <HIDDEN>,
+      "disable": <DISABLE>
+    }
+  }
+}
+
+WHERE:
+- <AGENT_GLOB> is String; glob pattern matched against subagent names in permission.task.
+- <AGENT_NAME> is String; agent id.
+- <DESCRIPTION> is String; required description of what the agent does and when to use it.
+- <DISABLE> is Boolean; true to disable the agent.
+- <HIDDEN> is Boolean; only applies to mode `subagent`.
+- <MODE> is one of AGENT_MODES.
+- <MODEL> is String; provider/model-id.
+- <PERMISSION_NAME> is String; permission key such as `edit`, `bash`, or `webfetch`.
+- <PERMISSION_VALUE> is String; one of `allow`, `ask`, or `deny`.
+- <STEPS> is Integer; maximum number of agentic steps.
+- <TASK_PERMISSION> is String; one of `allow`, `ask`, or `deny`.
+- <TOOL_ENABLED> is Boolean; true or false.
+- <TOOL_NAME> is String; tool id or wildcard pattern.
+</format>
+
+<format id="OPENCODE_COMMAND_CONFIG_JSON_V1" name="OpenCode Command Config JSON" purpose="JSON fragment for command-driven subagent routing in opencode.json or opencode.jsonc.">
+{
+  "command": {
+    "<COMMAND_NAME>": {
+      "agent": "<AGENT_NAME>",
+      "subtask": <SUBTASK>,
+      "model": "<MODEL>"
+    }
+  }
+}
+
+WHERE:
+- <AGENT_NAME> is String; agent id that executes the command.
+- <COMMAND_NAME> is String; command id.
+- <MODEL> is String; optional model override for the command execution.
+- <SUBTASK> is Boolean; true to force subagent invocation and isolate context.
+</format>
 </formats>

--- a/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
@@ -12,20 +12,59 @@ Use toolSet name to include all tools in a set, or qualifiedName for individual 
 The functionName is resolved automatically at runtime.
 Generated frontmatter MUST NOT contain YAML comments.
 Description MUST be a single-line quoted string (avoid YAML block scalars).
+You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring coordinator or worker agents.
+You SHOULD treat custom-agent subagents as leaf workers for portable APS authoring because nested delegation is not documented.
+You MUST map worker APS `<input>` fields to caller dispatch process args one-for-one.
 </instructions>
 
 <constants>
 PLATFORM_ID: "vscode-copilot"
 DISPLAY_NAME: "VS Code + GitHub Copilot"
-ADAPTER_VERSION: "2.0.0"
-LAST_UPDATED: "2026-02-19"
+ADAPTER_VERSION: "2.1.0"
+LAST_UPDATED: "2026-03-12"
 
-INSTRUCTION_FILE_PATHS: [".github/copilot-instructions.md", ".github/instructions/*.instructions.md"]
-AGENT_FILE_PATHS: [".github/agents/*.agent.md"]
-PROMPT_FILE_PATHS: [".github/prompts/*.prompt.md"]
-SKILL_FILE_PATHS: [".github/skills/<skill-id>/SKILL.md", "~/.copilot/skills/<skill-id>/SKILL.md"]
+ARTIFACT_TYPES: CSV<<
+type,scope,file_pattern,frontmatter_format
+agent,project,.github/agents/*.agent.md,VSCODE_AGENT_FRONTMATTER_V1
+agent,project,.claude/agents/*.md,VSCODE_AGENT_FRONTMATTER_V1
+agent,user,~/.copilot/agents/*.agent.md,VSCODE_AGENT_FRONTMATTER_V1
+prompt,project,.github/prompts/*.prompt.md,VSCODE_PROMPT_FRONTMATTER_V1
+instructions,project,.github/copilot-instructions.md,
+scoped-instructions,project,.github/instructions/*.instructions.md,VSCODE_INSTRUCTIONS_FRONTMATTER_V1
+skill,project,.github/skills/<skill-id>/SKILL.md,VSCODE_SKILL_FRONTMATTER_V1
+skill,personal,~/.copilot/skills/<skill-id>/SKILL.md,VSCODE_SKILL_FRONTMATTER_V1
+mcp-config,project,.vscode/mcp.json,
+>>
 
-DETECTION_MARKERS: [".github/copilot-instructions.md", ".github/agents", ".github/prompts", ".github/instructions", ".github/skills", ".vscode/mcp.json"]
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
+
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Main chat agent or prompt that can call agent/runSubagent",
+  "worker_role": "Built-in subagent or custom .agent.md agent used as a subagent",
+  "depth_policy": "portable-depth-1",
+  "documented_limit": "Custom-agent subagents are experimental and nested delegation is not documented.",
+  "invocation_tools": ["agent", "runSubagent"],
+  "definition_paths": [".github/agents/*.agent.md", ".claude/agents/*.md", "~/.copilot/agents/*.agent.md"],
+  "default_inheritance": {
+    "agent": "inherits the main agent",
+    "model": "inherits the main session unless overridden",
+    "tools": "inherits the main session unless overridden"
+  },
+  "controls": {
+    "subagent_allowlist": "agents",
+    "visible_in_picker": "user-invocable",
+    "subagent_disable": "disable-model-invocation",
+    "handoff_chain": "handoffs"
+  },
+  "request_contract_rule": "Define the worker <input> as the interface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "The worker returns a summary or typed result that the main agent incorporates before continuing.",
+  "portability_rule": "Keep coordinator-owned dispatch and leaf workers. Use handoffs for sequential flows."
+}
+>>
+
+AGENT_FILE_PATHS: [".github/agents/*.agent.md", ".claude/agents/*.md", "~/.copilot/agents/*.agent.md"]
+DETECTION_MARKERS: [".github/copilot-instructions.md", ".github/agents", ".claude/agents", ".github/prompts", ".github/instructions", ".github/skills", ".vscode/mcp.json"]
 
 MCP_CONFIG_PATHS: [".vscode/mcp.json"]
 
@@ -36,49 +75,49 @@ TOOL_FRONTMATTER_SYNTAX: "YAML array (no # prefix)"
 
 TOOLS: CSV<<
 name,toolset,qualified_name,function_name,mention,risk,side_effects,description
-semantic_search,search,search/codebase,semantic_search,#codebase,low,reads,"Search workspace for relevant code or documentation."
+semantic_search,search,search/codebase,semantic_search,#codebase,low,reads,"Search the workspace for relevant code or documentation."
 get_changed_files,search,search/changes,get_changed_files,#changes,low,reads,"Get git diffs of current file changes."
-list_code_usages,search,search/usages,list_code_usages,#usages,low,reads,"List usages of a function/class/variable."
+list_code_usages,search,search/usages,list_code_usages,#usages,low,reads,"List usages of a function, class, or variable."
 file_search,search,search/fileSearch,file_search,#fileSearch,low,reads,"Search for files by glob pattern."
-grep_search,search,search/textSearch,grep_search,#textSearch,low,reads,"Fast text search with exact string or regex."
+grep_search,search,search/textSearch,grep_search,#textSearch,low,reads,"Fast exact or regex text search."
 get_search_view_results,search,search/searchResults,get_search_view_results,#searchResults,low,reads,"Get results from the Search view."
-read_file,read,read/readFile,read_file,#readFile,low,reads,"Read contents of a file (1-indexed line range)."
+read_file,read,read/readFile,read_file,#readFile,low,reads,"Read contents of a file."
 get_errors,read,read/problems,get_errors,#problems,low,reads,"Get compile or lint errors."
-terminal_last_command,read,read/terminalLastCommand,terminal_last_command,#terminalLastCommand,low,reads,"Get last command run in active terminal."
-terminal_selection,read,read/terminalSelection,terminal_selection,#terminalSelection,low,reads,"Get current selection in active terminal."
-copilot_getNotebookSummary,read,read/notebookSummary,copilot_getNotebookSummary,#notebookSummary,low,reads,"Get list of Notebook cells with metadata."
-read_notebook_cell_output,read,read/notebookCellOutput,read_notebook_cell_output,#notebookCellOutput,low,reads,"Retrieve output for a notebook cell."
-create_directory,edit,edit/createDirectory,create_directory,#createDirectory,medium,writes,"Create a new directory structure (like mkdir -p)."
-create_file,edit,edit/createFile,create_file,#createFile,medium,writes,"Create a new file with specified content."
-replace_string_in_file,edit,edit/editFiles,replace_string_in_file,#editFiles,high,writes,"Replace a unique string in an existing file."
-multi_replace_string_in_file,edit,edit/multiEditFiles,multi_replace_string_in_file,#multiEditFiles,high,writes,"Apply multiple replacements in a single call."
-edit_notebook_file,edit,edit/editNotebook,edit_notebook_file,#editNotebook,high,writes,"Edit an existing Notebook file."
-create_new_jupyter_notebook,edit,edit/createNotebook,create_new_jupyter_notebook,#createNotebook,medium,writes,"Generate a new Jupyter Notebook."
+terminal_last_command,read,read/terminalLastCommand,terminal_last_command,#terminalLastCommand,low,reads,"Get the last command run in the active terminal."
+terminal_selection,read,read/terminalSelection,terminal_selection,#terminalSelection,low,reads,"Get the current terminal selection."
+copilot_getNotebookSummary,read,read/notebookSummary,copilot_getNotebookSummary,#notebookSummary,low,reads,"Get notebook cells with metadata."
+read_notebook_cell_output,read,read/notebookCellOutput,read_notebook_cell_output,#notebookCellOutput,low,reads,"Read notebook cell output."
+create_directory,edit,edit/createDirectory,create_directory,#createDirectory,medium,writes,"Create a directory structure."
+create_file,edit,edit/createFile,create_file,#createFile,medium,writes,"Create a new file with content."
+replace_string_in_file,edit,edit/editFiles,replace_string_in_file,#editFiles,high,writes,"Replace a unique string in a file."
+multi_replace_string_in_file,edit,edit/multiEditFiles,multi_replace_string_in_file,#multiEditFiles,high,writes,"Apply multiple replacements in one call."
+edit_notebook_file,edit,edit/editNotebook,edit_notebook_file,#editNotebook,high,writes,"Edit an existing notebook file."
+create_new_jupyter_notebook,edit,edit/createNotebook,create_new_jupyter_notebook,#createNotebook,medium,writes,"Create a new notebook."
 run_in_terminal,execute,execute/runInTerminal,run_in_terminal,#runInTerminal,high,executes,"Execute shell commands in a persistent terminal."
-get_terminal_output,execute,execute/getTerminalOutput,get_terminal_output,#getTerminalOutput,low,reads,"Get output of a terminal command."
+get_terminal_output,execute,execute/getTerminalOutput,get_terminal_output,#getTerminalOutput,low,reads,"Get terminal command output."
 run_task,execute,execute/runTask,run_task,#runTask,high,executes,"Run an existing VS Code task."
-create_and_run_task,execute,execute/createAndRunTask,create_and_run_task,#createAndRunTask,high,executes,"Create and run a build/run/custom task."
-get_task_output,execute,execute/getTaskOutput,get_task_output,#getTaskOutput,low,reads,"Get the output of a task."
-run_notebook_cell,execute,execute/runNotebookCell,run_notebook_cell,#runNotebookCell,high,executes,"Run a code cell in a notebook."
+create_and_run_task,execute,execute/createAndRunTask,create_and_run_task,#createAndRunTask,high,executes,"Create and run a task."
+get_task_output,execute,execute/getTaskOutput,get_task_output,#getTaskOutput,low,reads,"Get task output."
+run_notebook_cell,execute,execute/runNotebookCell,run_notebook_cell,#runNotebookCell,high,executes,"Run a notebook cell."
 test_failure,execute,execute/testFailure,test_failure,#testFailure,low,reads,"Include test failure information."
 fetch_webpage,web,web/fetch,fetch_webpage,#fetch,medium,network,"Fetch main content from web pages."
 github_repo,web,web/githubRepo,github_repo,#githubRepo,medium,network,"Search a GitHub repository for source code."
 run_vscode_command,vscode,vscode/runCommand,run_vscode_command,#runVscodeCommand,high,mixed,"Run a VS Code command."
-vscode_searchExtensions_internal,vscode,vscode/extensions,vscode_searchExtensions_internal,#extensions,low,network,"Browse VS Code Extensions Marketplace."
+vscode_searchExtensions_internal,vscode,vscode/extensions,vscode_searchExtensions_internal,#extensions,low,network,"Browse the VS Code Extensions Marketplace."
 install_extension,vscode,vscode/installExtension,install_extension,#installExtension,high,writes,"Install a VS Code extension."
 get_project_setup_info,vscode,vscode/getProjectSetupInfo,get_project_setup_info,#getProjectSetupInfo,low,none,"Get project setup info for scaffolding."
 open_simple_browser,vscode,vscode/openSimpleBrowser,open_simple_browser,#openSimpleBrowser,medium,none,"Preview a website in Simple Browser."
-create_new_workspace,vscode,vscode/newWorkspace,create_new_workspace,#newWorkspace,high,writes,"Get setup steps to create project structures."
+create_new_workspace,vscode,vscode/newWorkspace,create_new_workspace,#newWorkspace,high,writes,"Create a new workspace structure."
 get_vscode_api,vscode,vscode/vscodeAPI,get_vscode_api,#VSCodeAPI,low,none,"Get VS Code API documentation."
-runSubagent,agent,agent/runSubagent,runSubagent,#runSubagent,high,mixed,"Launch a new agent for complex multi-step tasks."
-get_selection,,selection,get_selection,#selection,low,reads,"Get current editor selection."
+runSubagent,agent,agent/runSubagent,runSubagent,#runSubagent,high,mixed,"Launch a new agent for isolated subagent work."
+get_selection,,selection,get_selection,#selection,low,reads,"Get the current editor selection."
 manage_todo_list,,todo,manage_todo_list,#todo,low,none,"Manage a structured todo list."
 >>
 
 RECOMMENDED_PLANNER_TOOLS: ["search/codebase", "search/fileSearch", "search/textSearch", "search/changes", "search/usages", "read/readFile", "read/problems", "todo", "web/fetch", "web/githubRepo"]
-RECOMMENDED_IMPLEMENTER_TOOLS: ["search/codebase", "search/fileSearch", "search/textSearch", "read/readFile", "read/problems", "edit/createDirectory", "edit/createFile", "edit/editFiles", "execute/runInTerminal", "execute/getTerminalOutput", "todo", "web/fetch", "web/githubRepo", "agent/runSubagent"]
+RECOMMENDED_IMPLEMENTER_TOOLS: ["search/codebase", "search/fileSearch", "search/textSearch", "read/readFile", "read/problems", "edit/createDirectory", "edit/createFile", "edit/editFiles", "execute/runInTerminal", "execute/getTerminalOutput", "todo", "web/fetch", "web/githubRepo", "agent", "agent/runSubagent"]
 
-AGENT_MODELS: ["Claude Haiku 4.5 (copilot)", "Claude Opus 4.5 (copilot)", "Claude Sonnet 4 (copilot)", "Claude Sonnet 4.5 (copilot)", "Gemini 2.5 Pro (copilot)", "GPT-4.1 (copilot)"]
+AGENT_MODELS: ["Claude Haiku 4.5 (copilot)", "Claude Opus 4.5 (copilot)", "Claude Sonnet 4 (copilot)", "Claude Sonnet 4.5 (copilot)", "Gemini 2.5 Pro (copilot)", "GPT-4.1 (copilot)", "GPT-5 (copilot)", "GPT-5.2 (copilot)"]
 
 AGENT_VERSIONING: JSON<<
 {
@@ -107,6 +146,7 @@ DOCS_AGENT_SKILLS_URL: "https://code.visualstudio.com/docs/copilot/customization
 DOCS_PROMPT_FILES_URL: "https://code.visualstudio.com/docs/copilot/customization/prompt-files"
 DOCS_MCP_URL: "https://code.visualstudio.com/docs/copilot/reference/mcp-configuration"
 DOCS_CUSTOM_AGENTS_URL: "https://code.visualstudio.com/docs/copilot/customization/custom-agents"
+DOCS_SUBAGENTS_URL: "https://code.visualstudio.com/docs/copilot/agents/subagents"
 DOCS_TOOLS_IN_CHAT_URL: "https://code.visualstudio.com/docs/copilot/chat/chat-tools"
 DOCS_TOOLS_REFERENCE_URL: "https://code.visualstudio.com/docs/copilot/reference/copilot-vscode-features"
 DOCS_CUSTOM_INSTRUCTIONS_URL: "https://code.visualstudio.com/docs/copilot/customization/custom-instructions"
@@ -117,19 +157,38 @@ DOCS_CUSTOM_INSTRUCTIONS_URL: "https://code.visualstudio.com/docs/copilot/custom
 ---
 name: <AGENT_NAME>
 description: "<AGENT_DESCRIPTION>"
+argument-hint: "<ARGUMENT_HINT>"
 tools: <TOOLS_ARRAY>
+agents: <AGENTS_ARRAY>
+model: <MODEL_OR_MODEL_ARRAY>
 user-invocable: <USER_INVOCABLE>
 disable-model-invocation: <DISABLE_MODEL_INVOCATION>
 target: <TARGET>
+handoffs:
+  - label: "<HANDOFF_LABEL>"
+    agent: <HANDOFF_AGENT>
+    prompt: "<HANDOFF_PROMPT>"
+    send: <HANDOFF_SEND>
+    model: <HANDOFF_MODEL>
+mcp-servers: <MCP_SERVERS_ARRAY>
 ---
 
 WHERE:
-- <AGENT_NAME> is String; the agent identifier shown in UI.
-- <AGENT_DESCRIPTION> is String; single-line quoted string describing agent purpose.
-- <TOOLS_ARRAY> is YAML array of tool qualified names or toolset names from TOOLS constant.
-- <USER_INVOCABLE> is Boolean; true if agent appears in the agents dropdown; default true.
-- <DISABLE_MODEL_INVOCATION> is Boolean; true to prevent invocation as subagent; default false.
-- <TARGET> is one of: "vscode", "github-copilot"; default "vscode".
+- <AGENT_DESCRIPTION> is String; single-line double-quoted description shown in chat.
+- <AGENT_NAME> is String; custom agent name. If omitted in a real file, the filename is used.
+- <AGENTS_ARRAY> is YAML array of agent names, `*`, or `[]`. If present, include `agent` or `agent/runSubagent` in <TOOLS_ARRAY>.
+- <ARGUMENT_HINT> is String; optional hint shown in the chat input field.
+- <DISABLE_MODEL_INVOCATION> is Boolean; true to prevent this agent from being invoked as a subagent.
+- <HANDOFF_AGENT> is String; target agent identifier for the handoff.
+- <HANDOFF_LABEL> is String; button label shown after the response completes.
+- <HANDOFF_MODEL> is String; qualified model name such as `GPT-5.2 (copilot)`; omit to reuse the current model.
+- <HANDOFF_PROMPT> is String; prompt text sent to the next agent.
+- <HANDOFF_SEND> is Boolean; true to auto-submit the handoff prompt.
+- <MCP_SERVERS_ARRAY> is YAML array of MCP server config objects; only applicable for target `github-copilot`.
+- <MODEL_OR_MODEL_ARRAY> is String or YAML array; use qualified model names in the format `Model Name (vendor)`.
+- <TARGET> is one of: `vscode`, `github-copilot`; default `vscode`.
+- <TOOLS_ARRAY> is YAML array of qualified names or tool set values from TOOLS; no `#` prefix.
+- <USER_INVOCABLE> is Boolean; true if the agent appears in the picker.
 </format>
 
 <format id="VSCODE_PROMPT_FRONTMATTER_V1" name="VS Code Prompt Frontmatter" purpose="YAML frontmatter contract for .github/prompts/*.prompt.md prompt files.">
@@ -140,9 +199,9 @@ tools: <TOOLS_ARRAY>
 ---
 
 WHERE:
-- <PROMPT_NAME> is String; the prompt name shown in UI.
-- <PROMPT_DESCRIPTION> is String; single-line quoted string describing what the prompt does.
-- <TOOLS_ARRAY> is YAML array of tool qualified names or toolset names from TOOLS constant.
+- <PROMPT_DESCRIPTION> is String; single-line double-quoted description of what the prompt does.
+- <PROMPT_NAME> is String; prompt name shown in the UI.
+- <TOOLS_ARRAY> is YAML array of qualified names or tool set values from TOOLS. Include `agent` or `agent/runSubagent` when the prompt invokes a subagent.
 </format>
 
 <format id="VSCODE_INSTRUCTIONS_FRONTMATTER_V1" name="VS Code Instructions Frontmatter" purpose="YAML frontmatter contract for .github/instructions/*.instructions.md files.">
@@ -152,8 +211,8 @@ description: "<INSTRUCTIONS_DESCRIPTION>"
 ---
 
 WHERE:
-- <GLOB_PATTERN> is String; comma-separated glob patterns (e.g., "**/*.ts,**/*.tsx").
-- <INSTRUCTIONS_DESCRIPTION> is String; describes the coding conventions in this file.
+- <GLOB_PATTERN> is String; comma-separated glob patterns such as `**/*.ts,**/*.tsx`.
+- <INSTRUCTIONS_DESCRIPTION> is String; single-line double-quoted description of the coding conventions in this file.
 </format>
 
 <format id="VSCODE_SKILL_FRONTMATTER_V1" name="VS Code Skill Frontmatter" purpose="YAML frontmatter contract for .github/skills/<id>/SKILL.md files.">
@@ -163,7 +222,7 @@ description: "<SKILL_DESCRIPTION>"
 ---
 
 WHERE:
-- <SKILL_NAME> is String; lowercase hyphenated skill identifier (e.g., "webapp-testing").
-- <SKILL_DESCRIPTION> is String; specific description so Copilot can auto-load the skill when relevant.
+- <SKILL_DESCRIPTION> is String; single-line double-quoted string so Copilot can auto-load the skill when relevant.
+- <SKILL_NAME> is String; lowercase hyphenated skill identifier such as `webapp-testing`.
 </format>
 </formats>


### PR DESCRIPTION
## Summary

Add cross-platform subagent (coordinator/worker) authoring support to all APS platform adapters, with a new portable authoring guide and conformance tests.

Refs: #55

## Motivation

APS-generated agents need to orchestrate subagents, but each platform wires coordinator/worker relationships differently — Claude Code uses the `Agent` tool with depth-1 limits, VS Code Copilot uses `agent/runSubagent` with experimental custom-agent support, OpenCode uses agent files. Platform adapters should document these differences so skill authors can write portable coordinator/worker patterns without encoding platform-specific assumptions.

## Changes

### Change Tree
```
# Legend: A = Added, M = Modified

skill/agnostic-prompt-standard/
├── SKILL.md                                                     # M: add guide references, update platform section
├── guides/
│   └── subagent-architecture-v1.0.0.guide.md                   # A: cross-platform coordinator/worker authoring guide
├── platforms/
│   ├── README.md                                                # M: add subagent authoring contract section
│   ├── _template/adaptor.md                                     # M: add SUBAGENT_AUTHORING_GUIDE, SUBAGENT_ARCHITECTURE
│   ├── claude-code/adaptor.md                                   # M: subagent constants, ARTIFACT_TYPES, expanded WHERE
│   ├── generic/adaptor.md                                       # M: subagent constants
│   ├── opencode/adaptor.md                                      # M: subagent constants, ARTIFACT_TYPES, expanded WHERE
│   └── vscode-copilot/adaptor.md                                # M: subagent constants, ARTIFACT_TYPES, expanded WHERE

AGENTS.md                                                        # M: update skill tree and folder descriptions

packages/aps-cli-node/
└── test/platform_adaptor_conformance.test.ts                    # M: add subagent constant conformance tests

packages/aps-cli-py/
└── tests/test_platform_manifest_fileconventions.py              # M: add subagent constant conformance tests
```

### Details

**New guide**
- `subagent-architecture-v1.0.0.guide.md`: Portable coordinator/worker authoring reference. Documents per-platform orchestration surfaces, depth policies, request/response contracts, and a depth-1 authoring pattern that works across all supported platforms.

**Platform adapter changes (all 5 adapters)**
- `SUBAGENT_AUTHORING_GUIDE`: Points to the new guide for coordinator/worker authoring.
- `SUBAGENT_ARCHITECTURE`: JSON constant documenting coordinator role, worker role, depth policy, invocation tools, definition paths, defaults, and portability rules.
- `ARTIFACT_TYPES`: CSV constant (claude-code, vscode-copilot, opencode) enumerating all artifact types with file patterns and frontmatter format references.
- Expanded `WHERE` clauses with subagent-specific fields: `background`, `maxTurns`, `memory`, `mcpServers`, `agents`, `handoffs`, `argument-hint`.
- `<instructions>` sections updated with subagent MUST rules (load guide, treat workers as leaf, map input fields).

**Platforms README**
- New "Subagent authoring contract" section specifying what adapters should document: coordinator/worker roles, dispatch surface, depth policy, input/output mapping, and the portable depth-1 default.

**Conformance tests**
- Node: `SUBAGENT_AUTHORING_GUIDE` presence + `SUBAGENT_ARCHITECTURE` object shape validation.
- Python: Mirror tests for parity.

## Testing

- [x] `npm test --prefix packages/aps-cli-node` — 49/49 passing
- [x] `cd packages/aps-cli-py && pytest -q tests` — 53/53 passing
- [ ] CI version consistency check