### PR TITLE
feat(cli): improve update command output clarity

### DIFF
--- a/packages/aps-cli-node/src/commands/update.ts
+++ b/packages/aps-cli-node/src/commands/update.ts
@@ -535,9 +535,25 @@ function renderTextReport(packageStatus: PackageUpdateStatus, targets: SkillUpda
   if (targets.length === 0) {
     console.log('- (none found)');
   } else {
+    const statusLabels: Record<string, string> = {
+      'updated': 'Refreshed',
+      'up-to-date': 'Up to date',
+      'update-available': 'Update available',
+      'missing': 'Not found',
+      'orphaned': 'Orphaned',
+    };
+
     for (const target of targets) {
-      const versionInfo = target.installedVersion ? `${target.installedVersion} -> ${target.desiredVersion}` : `target ${target.desiredVersion}`;
-      console.log(`- ${target.scope}: ${fmtPath(target.path)} [${target.status}] (${versionInfo})`);
+      const label = statusLabels[target.status] ?? target.status;
+      let versionInfo: string;
+      if (!target.installedVersion) {
+        versionInfo = `target ${target.desiredVersion}`;
+      } else if (target.installedVersion === target.desiredVersion) {
+        versionInfo = `reinstalled v${target.desiredVersion}`;
+      } else {
+        versionInfo = `${target.installedVersion} -> ${target.desiredVersion}`;
+      }
+      console.log(`- ${target.scope}: ${label} ${fmtPath(target.path)} (${versionInfo})`);
     }
   }
 
@@ -545,10 +561,24 @@ function renderTextReport(packageStatus: PackageUpdateStatus, targets: SkillUpda
     console.log('');
     console.log(options.check || options.dryRun ? 'Platform template updates:' : 'Platform template results:');
     for (const target of templateTargets) {
-      const summary = target.status === 'updated' 
-        ? `(${target.removed.length} old removed, ${target.copied.length} new written)`
-        : `(${target.status})`;
-      console.log(`- ${target.scope} templates (${target.platformId}): ${fmtPath(target.templateRoot)} ${summary}`);
+      if (target.status === 'updated' && (target.removed.length > 0 || target.copied.length > 0)) {
+        console.log(`  ${target.platformId} (${target.scope}):`);
+        if (target.removed.length > 0) {
+          console.log(`    Removed ${target.removed.length} old file(s):`);
+          for (const file of target.removed) {
+            console.log(`      - ${file}`);
+          }
+        }
+        if (target.copied.length > 0) {
+          console.log(`    Added ${target.copied.length} new file(s):`);
+          for (const file of target.copied) {
+            console.log(`      - ${file}`);
+          }
+        }
+      } else {
+        const statusLabel = target.status === 'up-to-date' ? 'up to date' : target.status;
+        console.log(`  - ${target.platformId} (${target.scope}): ${statusLabel}`);
+      }
     }
   }
 

--- a/packages/aps-cli-py/src/aps_cli/cli.py
+++ b/packages/aps-cli-py/src/aps_cli/cli.py
@@ -704,14 +704,24 @@ def _render_update_report(
     if not targets and not template_targets:
         console.print("- (none found)")
     elif targets:
+        status_labels = {
+            "updated": "Refreshed",
+            "up-to-date": "Up to date",
+            "update-available": "Update available",
+            "missing": "Not found",
+            "orphaned": "Orphaned",
+        }
+
         for target in targets:
-            version_info = (
-                f"{target.installed_version} -> {target.desired_version}"
-                if target.installed_version
-                else f"target {target.desired_version}"
-            )
+            label = status_labels.get(target.status, target.status)
+            if not target.installed_version:
+                version_info = f"target {target.desired_version}"
+            elif target.installed_version == target.desired_version:
+                version_info = f"reinstalled v{target.desired_version}"
+            else:
+                version_info = f"{target.installed_version} -> {target.desired_version}"
             console.print(
-                f"- {target.scope}: {_fmt_path(target.path)} [{target.status}] ({version_info})",
+                f"- {target.scope}: {label} {_fmt_path(target.path)} ({version_info})",
                 markup=False,
             )
 
@@ -719,15 +729,22 @@ def _render_update_report(
         console.print("")
         console.print("Platform template updates:" if (check or dry_run) else "Platform template results:")
         for target in template_targets:
-            summary = (
-                f"({len(target.removed)} old removed, {len(target.copied)} new written)"
-                if target.status == "updated"
-                else f"({target.status})"
-            )
-            console.print(
-                f"- {target.scope} templates ({target.platform_id}): {_fmt_path(target.template_root)} {summary}",
-                markup=False,
-            )
+            if target.status == "updated" and (target.removed or target.copied):
+                console.print(f"  {target.platform_id} ({target.scope}):", markup=False)
+                if target.removed:
+                    console.print(f"    Removed {len(target.removed)} old file(s):")
+                    for file in target.removed:
+                        console.print(f"      - {file}", markup=False)
+                if target.copied:
+                    console.print(f"    Added {len(target.copied)} new file(s):")
+                    for file in target.copied:
+                        console.print(f"      - {file}", markup=False)
+            else:
+                status_label = "up to date" if target.status == "up-to-date" else target.status
+                console.print(
+                    f"  - {target.platform_id} ({target.scope}): {status_label}",
+                    markup=False,
+                )
 
 
 @app.command()


### PR DESCRIPTION
## Summary
- Replace compressed template summaries (`2 old removed, 1 new written`) with individual file path listings so users can see exactly which agent files were removed and added
- Use human-friendly status labels (`Refreshed`, `Up to date`, `Update available`) instead of raw enum values (`[updated]`, `[up-to-date]`)
- Show `reinstalled v1.2.1` instead of confusing `1.2.1 -> 1.2.1` when force-refreshing at the same version
- Both Node and Python CLIs updated with identical output parity

### Before
```
Skill installation results:
- personal (claude): ~\.claude\skills\agnostic-prompt-standard [updated] (1.2.1 -> 1.2.1)

Platform template results:
- personal templates (claude-code): ~ (2 old removed, 1 new written)
```

### After
```
Skill installation results:
- personal (claude): Refreshed ~\.claude\skills\agnostic-prompt-standard (reinstalled v1.2.1)

Platform template results:
  claude-code (personal):
    Removed 2 old file(s):
      - .claude/agents/aps-v1.1.16.md
      - .claude/agents/aps-v1.1.17.md
    Added 1 new file(s):
      - .claude/agents/aps-v1.2.1.md
```

## Test plan
- [x] Node CLI: `npm test` — 60/60 pass
- [x] Python CLI: `pytest -q tests` — 65/65 pass
- [x] Manual verification: `aps update --dry-run` (compact status line)
- [x] Manual verification: `aps update --force --yes` (expanded file listings)
- [x] Output parity confirmed between Node and Python CLIs