### PR TITLE
feat(platforms): add GitHub Copilot CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ For Claude Code platform path (`.claude/skills`):
 npx @agnostic-prompt/aps init --platform claude-code
 ```
 
+For the standalone GitHub Copilot CLI (`.github/skills`, `~/.copilot/`):
+
+```bash
+npx @agnostic-prompt/aps init --platform copilot-cli
+```
+
 Validate your installation:
 
 ```bash
@@ -102,7 +108,7 @@ APS separates concerns into three layers:
 |-------|------|---------|
 | Specification | `references/` | Normative rules (structure, vocabulary, grammar, error taxonomy) |
 | Assets | `assets/` | Reusable templates and example components |
-| Platforms | `platforms/` | Adapters for specific hosts (VS Code Copilot, Claude Code, OpenCode) |
+| Platforms | `platforms/` | Adapters for specific hosts (VS Code Copilot, GitHub Copilot CLI, Claude Code, OpenCode) |
 
 The core abstraction is a structured envelope with seven ordered sections, from static instructions through executable processes to dynamic input.
 
@@ -116,7 +122,10 @@ skill/agnostic-prompt-standard/
 │   └── formats/            # Output format templates (tables, outlines, etc.)
 ├── platforms/
 │   ├── vscode-copilot/     # VS Code / Copilot adapter
+│   ├── copilot-cli/        # Standalone GitHub Copilot CLI adapter
 │   ├── claude-code/        # Claude Code adapter
+│   ├── opencode/           # OpenCode runtime adapter
+│   ├── generic/            # Tool-agnostic fallback
 │   ├── _schemas/           # JSON Schemas for validation
 │   └── _template/          # Starter template for new adapters
 ├── references/

--- a/packages/aps-cli-node/src/detection/adapters.ts
+++ b/packages/aps-cli-node/src/detection/adapters.ts
@@ -11,7 +11,12 @@ import {
 import { parseAdaptorMd } from '../parsers/adaptor.js';
 
 /** Known platform adapter identifiers. */
-export type KnownAdapterId = 'vscode-copilot' | 'claude-code' | 'opencode' | 'generic';
+export type KnownAdapterId =
+  | 'vscode-copilot'
+  | 'copilot-cli'
+  | 'claude-code'
+  | 'opencode'
+  | 'generic';
 
 /**
  * Result of detecting a platform adapter in a workspace.
@@ -34,6 +39,7 @@ export interface Marker {
 /** The default order of platform adapters for detection and display. */
 export const DEFAULT_ADAPTER_ORDER: readonly KnownAdapterId[] = [
   'vscode-copilot',
+  'copilot-cli',
   'claude-code',
   'opencode',
   'generic',

--- a/packages/aps-cli-node/test/detection.test.ts
+++ b/packages/aps-cli-node/test/detection.test.ts
@@ -327,5 +327,11 @@ test('formatDetectionLabel returns empty string for non-detected adapters', () =
 // ─────────────────────────────────────────────────────────────────────────────
 
 test('DEFAULT_ADAPTER_ORDER contains all known adapters in correct order', () => {
-  assert.deepEqual(DEFAULT_ADAPTER_ORDER, ['vscode-copilot', 'claude-code', 'opencode', 'generic']);
+  assert.deepEqual(DEFAULT_ADAPTER_ORDER, [
+    'vscode-copilot',
+    'copilot-cli',
+    'claude-code',
+    'opencode',
+    'generic',
+  ]);
 });

--- a/packages/aps-cli-py/src/aps_cli/core.py
+++ b/packages/aps-cli-py/src/aps_cli/core.py
@@ -13,9 +13,15 @@ from .parsers.adaptor import parse_adaptor_md, get_string, get_string_array
 
 SKILL_ID = "agnostic-prompt-standard"
 
-DEFAULT_ADAPTER_ORDER: tuple[str, ...] = ("vscode-copilot", "claude-code", "opencode", "generic")
+DEFAULT_ADAPTER_ORDER: tuple[str, ...] = (
+    "vscode-copilot",
+    "copilot-cli",
+    "claude-code",
+    "opencode",
+    "generic",
+)
 
-KnownAdapterId = Literal["vscode-copilot", "claude-code", "opencode", "generic"]
+KnownAdapterId = Literal["vscode-copilot", "copilot-cli", "claude-code", "opencode", "generic"]
 
 LEGACY_AGENT_NAMES = [
     "aps-prompt-protocol.agent.md",

--- a/packages/aps-cli-py/tests/test_core.py
+++ b/packages/aps-cli-py/tests/test_core.py
@@ -232,7 +232,13 @@ def test_compute_skill_destinations_empty_defaults_to_non_claude(tmp_path: Path)
 
 def test_default_adapter_order():
     """Test that DEFAULT_ADAPTER_ORDER contains known adapters."""
-    assert DEFAULT_ADAPTER_ORDER == ("vscode-copilot", "claude-code", "opencode", "generic")
+    assert DEFAULT_ADAPTER_ORDER == (
+        "vscode-copilot",
+        "copilot-cli",
+        "claude-code",
+        "opencode",
+        "generic",
+    )
 
 
 def test_sort_platforms_for_ui():

--- a/skill/agnostic-prompt-standard/platforms/README.md
+++ b/skill/agnostic-prompt-standard/platforms/README.md
@@ -23,9 +23,19 @@ platforms/
     adaptor.md                    # single source of truth
     templates/                    # optional installable agent files
       .claude/agents/             # (claude-code) or
-      .github/agents/             # (vscode-copilot)
+      .github/agents/             # (vscode-copilot, copilot-cli)
       # no templates/             # (generic / external tools)
 ```
+
+Currently shipped adapters:
+
+- `claude-code/` — Claude Code CLI (`.claude/agents/`, `~/.claude/`)
+- `vscode-copilot/` — GitHub Copilot in VS Code (`.github/agents/`, `~/.copilot/`)
+- `copilot-cli/` — Standalone GitHub Copilot CLI (`copilot` binary; `.github/agents/`, `~/.copilot/`)
+- `opencode/` — OpenCode runtime (`.opencode/agents/`, primary/subagent modes)
+- `generic/` — Tool-agnostic fallback for external tools and CI bots
+
+The `vscode-copilot` and `copilot-cli` adapters share the same install directories (`.github/`, `~/.copilot/`) by design — Copilot CLI was named `~/.copilot/` to be the canonical Copilot home — but expose different tool grammars, permission models, and orchestration surfaces. Pick the adapter that matches the **host process** (editor extension vs standalone CLI) you are running in.
 
 The `adaptor.md` file contains three APS sections:
 

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
@@ -1,0 +1,286 @@
+<instructions>
+Generate artifacts for the standalone GitHub Copilot CLI (`copilot` binary) using the constants and format contracts in this adapter.
+This adapter targets the standalone CLI, not the VS Code extension; use the `vscode-copilot` adapter for the editor surface.
+Tool names use snake_case with optional paren-arg specifiers (e.g., `shell(git commit)`, `shell(git:*)`, `web_fetch`).
+Built-in tools are `shell`, `read`, `write`, and `web_fetch`; MCP tools follow the pattern `<ServerName>(<tool_name>)`.
+Project agents live in `.github/agents/*.agent.md`; personal agents live in `~/.copilot/agents/*.agent.md`.
+When an agent name collides between project and personal scopes, the personal (home directory) agent wins.
+Project skills live in any of `.github/skills/`, `.claude/skills/`, or `.agents/skills/`; personal skills live in any of `~/.copilot/skills/`, `~/.claude/skills/`, or `~/.agents/skills/`.
+Project instructions live in `.github/copilot-instructions.md`; personal instructions live in `~/.copilot/copilot-instructions.md`.
+Scoped instructions live in `.github/instructions/*.instructions.md` and apply to files matching their `applyTo` glob.
+Hooks are first-class lifecycle scripts configured in `hooks.json` (cwd) or `.github/hooks/hooks.json` (repo).
+MCP servers are configured in `~/.copilot/mcp-config.json` (personal), `.mcp.json`, `.github/mcp.json`, or `.vscode/mcp.json` (project, in precedence order).
+Tool permissions are persisted in `~/.copilot/permissions-config.json` and can be set per-session via `--allow-tool` and `--deny-tool`.
+Deny rules always override allow rules in the permissions resolver.
+The configuration directory defaults to `~/.copilot` and can be relocated by setting `COPILOT_HOME` or passing `--config-dir`.
+Subagents are spawned via the `/fleet [PROMPT]` slash command (interactive REPL) or the `--autopilot` flag (non-interactive).
+You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring orchestrator or worker agents.
+You MUST treat `.agent.md` workers as leaf workers because the docs do not document nested `/fleet` delegation; we apply `depth-1-only` for portability.
+You MUST map worker APS `<input>` fields to caller dispatch process args one-for-one.
+Generated frontmatter MUST NOT contain YAML comments.
+Description fields MUST be a single-line quoted string (avoid YAML block scalars).
+Skills installed under `.claude/skills/` or `~/.claude/skills/` by `aps init --platform claude-code` are automatically discoverable by the Copilot CLI per official docs; cross-platform skill reuse is supported with no extra wiring.
+</instructions>
+
+<constants>
+PLATFORM_ID: "copilot-cli"
+DISPLAY_NAME: "GitHub Copilot CLI"
+ADAPTER_VERSION: "1.0.0"
+LAST_UPDATED: "2026-04-08"
+
+ARTIFACT_TYPES: CSV<<
+type,scope,file_pattern,frontmatter_format
+agent,project,.github/agents/*.agent.md,COPILOT_CLI_AGENT_FRONTMATTER_V1
+agent,personal,~/.copilot/agents/*.agent.md,COPILOT_CLI_AGENT_FRONTMATTER_V1
+skill,project,.github/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+skill,project,.claude/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+skill,project,.agents/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+skill,personal,~/.copilot/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+skill,personal,~/.claude/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+skill,personal,~/.agents/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
+instructions,project,.github/copilot-instructions.md,
+instructions,personal,~/.copilot/copilot-instructions.md,
+scoped-instructions,project,.github/instructions/*.instructions.md,COPILOT_CLI_INSTRUCTIONS_FRONTMATTER_V1
+hooks,project,.github/hooks/hooks.json,COPILOT_CLI_HOOKS_CONFIG_V1
+hooks,project,hooks.json,COPILOT_CLI_HOOKS_CONFIG_V1
+mcp-config,personal,~/.copilot/mcp-config.json,COPILOT_CLI_MCP_CONFIG_V1
+mcp-config,project,.github/mcp.json,COPILOT_CLI_MCP_CONFIG_V1
+mcp-config,project,.mcp.json,COPILOT_CLI_MCP_CONFIG_V1
+permissions,personal,~/.copilot/permissions-config.json,COPILOT_CLI_PERMISSIONS_V1
+config,personal,~/.copilot/config.json,COPILOT_CLI_CONFIG_V1
+>>
+
+SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
+
+SUBAGENT_ARCHITECTURE: JSON<<
+{
+  "coordinator_role": "Main copilot session (interactive REPL or non-interactive `copilot -p \"...\"` invocation)",
+  "worker_role": "Custom .agent.md agent invoked via the /fleet slash command",
+  "depth_policy": "depth-1-only",
+  "documented_limit": "Nested /fleet delegation is not documented; the orchestrator decides feasibility per task. APS treats this as depth-1 for portability.",
+  "invocation_surface": "/fleet [PROMPT] slash command (interactive) or --autopilot flag (non-interactive)",
+  "definition_paths": [".github/agents/*.agent.md", "~/.copilot/agents/*.agent.md"],
+  "name_collision_rule": "When the same agent name exists in both project and personal scopes, the personal (~/.copilot/agents/) version wins.",
+  "default_inheritance": {
+    "model": "inherits the orchestrator session model unless overridden",
+    "tools": "inherits the orchestrator allow/deny set unless restricted via allowed-tools"
+  },
+  "controls": {
+    "tool_allowlist": "allowed-tools",
+    "permission_gate": "permissions-config.json + --allow-tool / --deny-tool",
+    "hook_gate": "preToolUse hooks can deny a tool invocation by exiting non-zero"
+  },
+  "request_contract_rule": "Define the worker <input> as the public request interface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "The worker returns a typed result or bounded summary that the orchestrator captures before continuing.",
+  "portability_rule": "Author Copilot CLI workers as leaf workers. Keep host-specific /fleet routing in the caller dispatch layer."
+}
+>>
+
+INSTRUCTION_FILE_PATHS: [".github/copilot-instructions.md", "~/.copilot/copilot-instructions.md", "AGENTS.md", "CLAUDE.md", "GEMINI.md"]
+AGENT_FILE_PATHS: [".github/agents/*.agent.md", "~/.copilot/agents/*.agent.md"]
+SKILL_FILE_PATHS: [".github/skills", ".claude/skills", ".agents/skills", "~/.copilot/skills", "~/.claude/skills", "~/.agents/skills"]
+MCP_CONFIG_PATHS: ["~/.copilot/mcp-config.json", ".github/mcp.json", ".mcp.json", ".vscode/mcp.json"]
+HOOK_CONFIG_PATHS: [".github/hooks/hooks.json", "hooks.json"]
+PERMISSIONS_CONFIG_PATHS: ["~/.copilot/permissions-config.json"]
+
+DETECTION_MARKERS: [".github/copilot-instructions.md", ".github/agents", ".github/skills", ".github/hooks", ".github/instructions", ".github/mcp.json", "~/.copilot/config.json", "~/.copilot/copilot-instructions.md"]
+
+CONFIG_HOME_ENV: "COPILOT_HOME"
+CONFIG_HOME_DEFAULT: "~/.copilot"
+CONFIG_DIR_FLAG: "--config-dir"
+
+TOOL_NAMING_STYLE: "snake_case with optional paren-arg specifiers (e.g., shell(git commit), shell(git:*), web_fetch)"
+TOOL_NAMING_QUALIFICATION: "paren-arg for command-scoped or wildcard restrictions"
+TOOL_BUILT_IN: ["shell", "read", "write", "web_fetch"]
+TOOL_MCP_PATTERN: "<ServerName>(<tool_name>)"
+TOOL_PERMISSION_PRECEDENCE: "deny overrides allow"
+
+TOOLS: CSV<<
+name,toolset,risk,side_effects,description,permission_examples
+shell,builtin,high,executes,"Execute shell commands. Supports per-command scoping and wildcards.","[shell, shell(git commit), shell(git:*), shell(npm test)]"
+read,builtin,low,reads,"Read file contents from the workspace.","[read, read(src/**)]"
+write,builtin,medium,writes,"Create or overwrite files in the workspace.","[write, write(src/**)]"
+web_fetch,builtin,medium,network,"Fetch and process URL content.","[web_fetch]"
+>>
+
+SUBAGENT_INVOCATION_COMMANDS: ["/fleet", "--autopilot"]
+SLASH_COMMANDS: ["/fleet", "/help", "/login", "/logout", "/model", "/skills", "/agents", "/quit"]
+
+HOOK_EVENTS: ["sessionStart", "sessionEnd", "userPromptSubmitted", "preToolUse", "postToolUse", "errorOccurred"]
+HOOK_PLATFORMS: ["bash", "powershell"]
+HOOK_DENY_RULE: "preToolUse hooks can deny a tool invocation by exiting with a non-zero status."
+
+INSTALLATION_METHODS: ["npm install -g @github/copilot", "brew install copilot-cli", "winget install GitHub.Copilot", "curl -fsSL https://gh.io/copilot-install | bash"]
+
+AGENT_VERSIONING: JSON<<
+{
+  "templates": [
+    {
+      "path": "templates/.github/agents/aps-v{major}.{minor}.{patch}.agent.md",
+      "current_path": "templates/.github/agents/aps-v1.2.1.agent.md",
+      "frontmatter": {
+        "name_pattern": "APS v{major}.{minor}.{patch} Agent",
+        "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md files for the Copilot CLI: detect artifact type from user intent, load APS+Copilot CLI adapter, extract intent, then generate+write+lint."
+      }
+    }
+  ]
+}
+>>
+
+SKILL_AUTHORING_RESOURCES: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
+}
+>>
+
+CROSS_PLATFORM_INTEROP: JSON<<
+{
+  "shared_skill_paths": [".claude/skills", "~/.claude/skills", ".agents/skills", "~/.agents/skills"],
+  "rationale": "Per docs.github.com, the Copilot CLI also reads .claude/skills, ~/.claude/skills, .agents/skills, and ~/.agents/skills. Skills installed via `aps init --platform claude-code` are therefore automatically discoverable by the Copilot CLI without re-running init.",
+  "shared_agent_paths": [],
+  "shared_instruction_paths": ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]
+}
+>>
+
+DOCS_HOME_URL: "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
+DOCS_AGENTS_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli"
+DOCS_SKILLS_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-skills"
+DOCS_INSTRUCTIONS_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions"
+DOCS_HOOKS_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks"
+DOCS_MCP_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers"
+DOCS_TOOLS_URL: "https://docs.github.com/en/copilot/how-tos/copilot-cli/allowing-tools"
+DOCS_FLEET_URL: "https://docs.github.com/en/copilot/concepts/agents/copilot-cli/fleet"
+DOCS_CONFIG_DIR_URL: "https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference"
+</constants>
+
+<formats>
+<format id="COPILOT_CLI_AGENT_FRONTMATTER_V1" name="Copilot CLI Agent Frontmatter" purpose="YAML frontmatter contract for .github/agents/*.agent.md and ~/.copilot/agents/*.agent.md custom agent files.">
+---
+name: <AGENT_NAME>
+description: "<AGENT_DESCRIPTION>"
+model: <MODEL>
+allowed-tools: <ALLOWED_TOOLS_ARRAY>
+mcp-servers: <MCP_SERVERS_ARRAY>
+---
+
+WHERE:
+- <AGENT_NAME> is String; lowercase-hyphenated agent identifier; the markdown filename minus the `.agent.md` suffix is used when omitted.
+- <AGENT_DESCRIPTION> is String; single-line double-quoted description shown when the agent is listed or invoked.
+- <MODEL> is String; optional model id; omit to inherit the orchestrator session model.
+- <ALLOWED_TOOLS_ARRAY> is YAML array of snake_case tool names or paren-arg patterns from TOOLS (e.g., `shell(git:*)`, `read`, `write`, `web_fetch`); omit to inherit the orchestrator allow set.
+- <MCP_SERVERS_ARRAY> is YAML array of MCP server ids that the agent may use; omit to inherit the session set.
+</format>
+
+<format id="COPILOT_CLI_SKILL_FRONTMATTER_V1" name="Copilot CLI Skill Frontmatter" purpose="YAML frontmatter contract for SKILL.md files under .github/skills/, .claude/skills/, .agents/skills/, ~/.copilot/skills/, ~/.claude/skills/, or ~/.agents/skills/.">
+---
+name: <SKILL_NAME>
+description: "<SKILL_DESCRIPTION>"
+license: <LICENSE>
+allowed-tools: <ALLOWED_TOOLS_ARRAY>
+---
+
+WHERE:
+- <SKILL_NAME> is String; lowercase hyphenated skill identifier such as `agnostic-prompt-standard`.
+- <SKILL_DESCRIPTION> is String; single-line double-quoted description so the CLI can auto-load the skill when relevant.
+- <LICENSE> is String; optional SPDX license id (e.g., `MIT`, `Apache-2.0`).
+- <ALLOWED_TOOLS_ARRAY> is YAML array of snake_case tool names or paren-arg patterns; omit to inherit the session allow set.
+</format>
+
+<format id="COPILOT_CLI_INSTRUCTIONS_FRONTMATTER_V1" name="Copilot CLI Instructions Frontmatter" purpose="YAML frontmatter contract for .github/instructions/*.instructions.md path-scoped instructions.">
+---
+applyTo: "<GLOB_PATTERN>"
+description: "<INSTRUCTIONS_DESCRIPTION>"
+---
+
+WHERE:
+- <GLOB_PATTERN> is String; comma-separated glob patterns such as `**/*.ts,**/*.tsx`.
+- <INSTRUCTIONS_DESCRIPTION> is String; single-line double-quoted description of the conventions captured in this file.
+</format>
+
+<format id="COPILOT_CLI_HOOKS_CONFIG_V1" name="Copilot CLI Hooks Config" purpose="JSON structure for hooks.json (cwd) or .github/hooks/hooks.json (repo).">
+{
+  "<HOOK_EVENT>": [
+    {
+      "matcher": "<MATCHER_PATTERN>",
+      "bash": "<BASH_COMMAND>",
+      "powershell": "<POWERSHELL_COMMAND>",
+      "cwd": "<CWD_PATH>",
+      "timeoutSec": <TIMEOUT_SEC>,
+      "env": {
+        "<ENV_KEY>": "<ENV_VALUE>"
+      }
+    }
+  ]
+}
+
+WHERE:
+- <HOOK_EVENT> is one of HOOK_EVENTS.
+- <MATCHER_PATTERN> is String; tool name or paren-arg pattern to match (e.g., `shell(git commit)`); omit for unconditional hooks.
+- <BASH_COMMAND> is String; shell command to execute on POSIX systems.
+- <POWERSHELL_COMMAND> is String; shell command to execute on Windows systems.
+- <CWD_PATH> is String; optional working directory for the hook command.
+- <TIMEOUT_SEC> is Integer; optional timeout in seconds before the hook is killed.
+- <ENV_KEY> and <ENV_VALUE> are Strings; optional environment variables passed to the hook process.
+- A `preToolUse` hook that exits non-zero denies the matching tool invocation.
+</format>
+
+<format id="COPILOT_CLI_MCP_CONFIG_V1" name="Copilot CLI MCP Config" purpose="JSON structure for ~/.copilot/mcp-config.json, .mcp.json, .github/mcp.json, or .vscode/mcp.json.">
+{
+  "mcpServers": {
+    "<SERVER_NAME>": {
+      "type": "<SERVER_TYPE>",
+      "command": "<COMMAND>",
+      "args": ["<ARG>"],
+      "url": "<URL>",
+      "headers": {
+        "<HEADER_KEY>": "<HEADER_VALUE>"
+      },
+      "env": {
+        "<ENV_KEY>": "<ENV_VALUE>"
+      },
+      "tools": ["<TOOL_NAME>"]
+    }
+  }
+}
+
+WHERE:
+- <SERVER_NAME> is String; unique server id used in `<ServerName>(<tool_name>)` tool references.
+- <SERVER_TYPE> is one of `local`, `stdio`, `http`, `sse`.
+- <COMMAND> is String; executable for `local` or `stdio` servers; omit for `http`/`sse`.
+- <ARG> is String; command-line argument for `local`/`stdio` servers.
+- <URL> is String; endpoint URL for `http` or `sse` servers; omit for `local`/`stdio`.
+- <HEADER_KEY>/<HEADER_VALUE> are Strings; optional HTTP headers for `http`/`sse` servers.
+- <ENV_KEY>/<ENV_VALUE> are Strings; optional environment variables for `local`/`stdio` servers.
+- <TOOL_NAME> is String; optional allowlist of tool names exposed by the server; omit to expose all advertised tools.
+- The built-in GitHub MCP server is enabled by default; disable it with the `--disable-builtin-mcps` flag.
+</format>
+
+<format id="COPILOT_CLI_PERMISSIONS_V1" name="Copilot CLI Permissions Config" purpose="JSON structure for ~/.copilot/permissions-config.json.">
+{
+  "allow": ["<TOOL_PATTERN>"],
+  "deny": ["<TOOL_PATTERN>"]
+}
+
+WHERE:
+- <TOOL_PATTERN> is String; snake_case tool name or paren-arg pattern (e.g., `shell`, `shell(git:*)`, `web_fetch`, `<ServerName>(<tool_name>)`).
+- Deny rules always override allow rules.
+- Patterns added at runtime via `--allow-tool` and `--deny-tool` are merged into this file.
+</format>
+
+<format id="COPILOT_CLI_CONFIG_V1" name="Copilot CLI Config" purpose="JSON structure for ~/.copilot/config.json.">
+{
+  "model": "<MODEL>",
+  "theme": "<THEME>",
+  "trusted_folders": ["<FOLDER_PATH>"],
+  "telemetry": <TELEMETRY>
+}
+
+WHERE:
+- <MODEL> is String; default model id used when no per-session override is supplied.
+- <THEME> is String; UI theme id (e.g., `dark`, `light`).
+- <FOLDER_PATH> is String; absolute path to a folder the user has marked as trusted.
+- <TELEMETRY> is Boolean; whether anonymized telemetry is enabled.
+</format>
+</formats>

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
@@ -1,37 +1,53 @@
 <instructions>
 Generate artifacts for the standalone GitHub Copilot CLI (`copilot` binary) using the constants and format contracts in this adapter.
 This adapter targets the standalone CLI, not the VS Code extension; use the `vscode-copilot` adapter for the editor surface.
-Tool names use snake_case with optional paren-arg specifiers (e.g., `shell(git commit)`, `shell(git:*)`, `web_fetch`).
-Built-in tools are `shell`, `read`, `write`, and `web_fetch`; MCP tools follow the pattern `<ServerName>(<tool_name>)`.
-Project agents live in `.github/agents/*.agent.md`; personal agents live in `~/.copilot/agents/*.agent.md`.
+Copilot CLI uses TWO distinct grammars: tool names (used inside agent `tools:` arrays) and permission patterns (used by `--allow-tool`, `--deny-tool`, and `permissions-config.json`).
+Tool names are bare snake_case identifiers from TOOL_BUILT_IN, plus `<server>/<tool>` slash notation for MCP tools (e.g., `bash`, `view`, `web_fetch`, `github-mcp-server/get_pull_request`).
+Permission patterns use `kind(arg?)` form where kind is one of `shell`, `write`, `url`, or an MCP server name (e.g., `shell(git:*)`, `write`, `url(https://*.github.com)`, `github-mcp-server(get_pull_request)`).
+The `shell(<command>:*)` form scopes a permission to a command family by stem prefix; `shell(git:*)` matches `git push` but not `gitea`.
+The `write` permission category covers the `create` and `edit` tools but does NOT include shell redirections; use `--allow-all-tools` to allow shell redirections.
+Deny rules always override allow rules in the permissions resolver, even `--allow-all-tools`.
+Custom agents are stored in TWO supported formats: `.agent.yaml` (native, used by bundled Copilot CLI agents) and `.agent.md` (VSCode-format compatibility, parsed since the v1.0.x release per the changelog).
+Native `.agent.yaml` files have the schema declared in COPILOT_CLI_AGENT_YAML_V1; VSCode-format `.agent.md` files have the schema declared in COPILOT_CLI_AGENT_MD_V1.
+Project agents live in `.github/agents/`; personal agents live in `~/.copilot/agents/`.
 When an agent name collides between project and personal scopes, the personal (home directory) agent wins.
 Project skills live in any of `.github/skills/`, `.claude/skills/`, or `.agents/skills/`; personal skills live in any of `~/.copilot/skills/`, `~/.claude/skills/`, or `~/.agents/skills/`.
-Project instructions live in `.github/copilot-instructions.md`; personal instructions live in `~/.copilot/copilot-instructions.md`.
+Project instructions live in `.github/copilot-instructions.md`; personal instructions live in `~/.copilot/copilot-instructions.md`; the loader also reads `AGENTS.md` and related custom-instructions files.
+Additional custom-instructions search directories can be added via the `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` environment variable.
 Scoped instructions live in `.github/instructions/*.instructions.md` and apply to files matching their `applyTo` glob.
-Hooks are first-class lifecycle scripts configured in `hooks.json` (cwd) or `.github/hooks/hooks.json` (repo).
-MCP servers are configured in `~/.copilot/mcp-config.json` (personal), `.mcp.json`, `.github/mcp.json`, or `.vscode/mcp.json` (project, in precedence order).
+Lifecycle hooks are first-class and configured in `hooks.json` (cwd) or `hooks/hooks.json` (subdirectory variant); the loader also walks the project tree for these literal paths.
+The hook event vocabulary in HOOK_EVENTS is deliberately Claude-Code-compatible per the SDK comment "Matches Claude Code terminology; extensible for future stop reasons."
+A `preToolUse` hook that exits non-zero (or returns `decision: "block"` from the SDK) denies the matching tool invocation.
+MCP servers are configured in `~/.copilot/mcp-config.json` (personal); per-session additions are passed via `--additional-mcp-config <json|@file>`.
+The built-in MCP server is `github-mcp-server`; disable it with `--disable-builtin-mcps` or scope its tools with `--add-github-mcp-tool` and `--add-github-mcp-toolset`.
 Tool permissions are persisted in `~/.copilot/permissions-config.json` and can be set per-session via `--allow-tool` and `--deny-tool`.
-Deny rules always override allow rules in the permissions resolver.
-The configuration directory defaults to `~/.copilot` and can be relocated by setting `COPILOT_HOME` or passing `--config-dir`.
-Subagents are spawned via the `/fleet [PROMPT]` slash command (interactive REPL) or the `--autopilot` flag (non-interactive).
+File access is restricted to the cwd and the system temp directory by default; expand with `--add-dir`, disable verification with `--allow-all-paths`, or block temp access with `--disallow-temp-dir`.
+URL access is gated by `--allow-url` / `--deny-url` and the `allowed_urls` / `denied_urls` config keys; all URL patterns are protocol-aware.
+The configuration directory defaults to `~/.copilot` and can be relocated by setting the `COPILOT_HOME` environment variable or passing `--config-dir <directory>`.
+Subagents have multiple invocation surfaces: the built-in `task` tool (programmatic, used inside agent `tools:` arrays), the `/fleet` slash command (interactive REPL — enables fleet mode for parallel subagent execution), the `--agent <agent>` flag (selects the active agent for a session), and `--autopilot` (non-interactive continuation mode).
 You MUST load `guides/subagent-architecture-v1.0.0.guide.md` before authoring orchestrator or worker agents.
-You MUST treat `.agent.md` workers as leaf workers because the docs do not document nested `/fleet` delegation; we apply `depth-1-only` for portability.
+You MUST treat custom workers as leaf workers because nested `/fleet` delegation is not documented; we apply `depth-1-only` for portability.
 You MUST map worker APS `<input>` fields to caller dispatch process args one-for-one.
 Generated frontmatter MUST NOT contain YAML comments.
-Description fields MUST be a single-line quoted string (avoid YAML block scalars).
+Description fields MUST be a single-line quoted string (avoid YAML block scalars) when authoring `.agent.md` (VSCode-format) files; native `.agent.yaml` files MAY use YAML block scalars for `description` and `prompt`.
 Skills installed under `.claude/skills/` or `~/.claude/skills/` by `aps init --platform claude-code` are automatically discoverable by the Copilot CLI per official docs; cross-platform skill reuse is supported with no extra wiring.
+The Copilot CLI ships a built-in `fetch_copilot_cli_documentation` tool that the model can use to self-introspect against current GitHub docs; APS authors MAY rely on this tool when authoring agents that target Copilot CLI.
+You MUST NOT use the `read` or `write` strings as tool names in agent `tools:` arrays — those are permission categories. Use `view` (read), `create` (new file), and `edit` (modify file) as tool names instead.
 </instructions>
 
 <constants>
 PLATFORM_ID: "copilot-cli"
 DISPLAY_NAME: "GitHub Copilot CLI"
-ADAPTER_VERSION: "1.0.0"
+ADAPTER_VERSION: "1.1.0"
 LAST_UPDATED: "2026-04-08"
+VERIFIED_AGAINST_BINARY_VERSION: "1.0.3"
 
 ARTIFACT_TYPES: CSV<<
 type,scope,file_pattern,frontmatter_format
-agent,project,.github/agents/*.agent.md,COPILOT_CLI_AGENT_FRONTMATTER_V1
-agent,personal,~/.copilot/agents/*.agent.md,COPILOT_CLI_AGENT_FRONTMATTER_V1
+agent,project,.github/agents/*.agent.yaml,COPILOT_CLI_AGENT_YAML_V1
+agent,project,.github/agents/*.agent.md,COPILOT_CLI_AGENT_MD_V1
+agent,personal,~/.copilot/agents/*.agent.yaml,COPILOT_CLI_AGENT_YAML_V1
+agent,personal,~/.copilot/agents/*.agent.md,COPILOT_CLI_AGENT_MD_V1
 skill,project,.github/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
 skill,project,.claude/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
 skill,project,.agents/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
@@ -39,15 +55,15 @@ skill,personal,~/.copilot/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATT
 skill,personal,~/.claude/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
 skill,personal,~/.agents/skills/<skill-id>/SKILL.md,COPILOT_CLI_SKILL_FRONTMATTER_V1
 instructions,project,.github/copilot-instructions.md,
+instructions,project,AGENTS.md,
 instructions,personal,~/.copilot/copilot-instructions.md,
 scoped-instructions,project,.github/instructions/*.instructions.md,COPILOT_CLI_INSTRUCTIONS_FRONTMATTER_V1
-hooks,project,.github/hooks/hooks.json,COPILOT_CLI_HOOKS_CONFIG_V1
 hooks,project,hooks.json,COPILOT_CLI_HOOKS_CONFIG_V1
+hooks,project,hooks/hooks.json,COPILOT_CLI_HOOKS_CONFIG_V1
 mcp-config,personal,~/.copilot/mcp-config.json,COPILOT_CLI_MCP_CONFIG_V1
-mcp-config,project,.github/mcp.json,COPILOT_CLI_MCP_CONFIG_V1
-mcp-config,project,.mcp.json,COPILOT_CLI_MCP_CONFIG_V1
 permissions,personal,~/.copilot/permissions-config.json,COPILOT_CLI_PERMISSIONS_V1
 config,personal,~/.copilot/config.json,COPILOT_CLI_CONFIG_V1
+plugin-registry,personal,~/.copilot/installed-plugins/,
 >>
 
 SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
@@ -55,62 +71,190 @@ SUBAGENT_AUTHORING_GUIDE: "guides/subagent-architecture-v1.0.0.guide.md"
 SUBAGENT_ARCHITECTURE: JSON<<
 {
   "coordinator_role": "Main copilot session (interactive REPL or non-interactive `copilot -p \"...\"` invocation)",
-  "worker_role": "Custom .agent.md agent invoked via the /fleet slash command",
+  "worker_role": "Custom .agent.yaml or .agent.md agent invoked via the task tool, /fleet slash command, or --agent flag",
   "depth_policy": "depth-1-only",
-  "documented_limit": "Nested /fleet delegation is not documented; the orchestrator decides feasibility per task. APS treats this as depth-1 for portability.",
-  "invocation_surface": "/fleet [PROMPT] slash command (interactive) or --autopilot flag (non-interactive)",
-  "definition_paths": [".github/agents/*.agent.md", "~/.copilot/agents/*.agent.md"],
+  "documented_limit": "Nested /fleet delegation is not documented. APS treats this as depth-1 for portability.",
+  "invocation_surfaces": [
+    {
+      "name": "task tool",
+      "kind": "built-in tool",
+      "where": "Listed inside an agent `tools:` array; called programmatically by the model.",
+      "context_isolation": "Runs in a separate context window per invocation."
+    },
+    {
+      "name": "/fleet",
+      "kind": "interactive slash command",
+      "where": "Typed in the REPL after starting `copilot`.",
+      "semantics": "Enables fleet mode for parallel subagent execution; persists for the rest of the session."
+    },
+    {
+      "name": "--agent <agent>",
+      "kind": "CLI flag",
+      "where": "Passed to `copilot` at startup.",
+      "semantics": "Selects the active agent for the session; the named agent must exist in `.github/agents/` or `~/.copilot/agents/` (or be a bundled agent like task/explore/code-review/research)."
+    },
+    {
+      "name": "--autopilot",
+      "kind": "CLI flag",
+      "where": "Used with -p/--prompt for non-interactive execution.",
+      "semantics": "Enables autopilot continuation mode; capped by --max-autopilot-continues."
+    }
+  ],
+  "definition_paths": [".github/agents/*.agent.yaml", ".github/agents/*.agent.md", "~/.copilot/agents/*.agent.yaml", "~/.copilot/agents/*.agent.md"],
   "name_collision_rule": "When the same agent name exists in both project and personal scopes, the personal (~/.copilot/agents/) version wins.",
   "default_inheritance": {
-    "model": "inherits the orchestrator session model unless overridden",
-    "tools": "inherits the orchestrator allow/deny set unless restricted via allowed-tools"
+    "model": "inherits the orchestrator session model unless the agent declares `model:`",
+    "tools": "inherits the orchestrator allow/deny set unless restricted via the agent's `tools:` array or runtime --available-tools/--excluded-tools filters"
   },
   "controls": {
-    "tool_allowlist": "allowed-tools",
-    "permission_gate": "permissions-config.json + --allow-tool / --deny-tool",
-    "hook_gate": "preToolUse hooks can deny a tool invocation by exiting non-zero"
+    "tool_filter": "--available-tools (whitelist) and --excluded-tools (blacklist) decide which tools the model can see",
+    "permission_gate": "permissions-config.json + --allow-tool / --deny-tool control approval prompts (do NOT expose tools that the filter hides)",
+    "hook_gate": "preToolUse hooks can deny a tool invocation by exiting non-zero or returning {decision: 'block'}"
   },
-  "request_contract_rule": "Define the worker <input> as the public request interface and mirror it in the caller dispatch process args.",
-  "response_contract_rule": "The worker returns a typed result or bounded summary that the orchestrator captures before continuing.",
-  "portability_rule": "Author Copilot CLI workers as leaf workers. Keep host-specific /fleet routing in the caller dispatch layer."
+  "bundled_workers": [
+    {"name": "task", "model": "claude-haiku-4.5", "purpose": "Execute development commands (tests, builds, lints, formatters); brief on success, verbose on failure."},
+    {"name": "explore", "model": "claude-haiku-4.5", "purpose": "Fast codebase exploration via grep/glob/view/bash/lsp + read-only github-mcp-server + bluebird semantic search."},
+    {"name": "code-review", "model": "claude-sonnet-4.5", "purpose": "High-signal code review of staged/unstaged or branch diffs; only surfaces real bugs."},
+    {"name": "research", "model": "claude-sonnet-4.6", "purpose": "Exhaustive research using github MCP, web_search, web_fetch, and the task subagent."}
+  ],
+  "request_contract_rule": "Define the worker `tools:` array as the public capability surface and mirror it in the caller dispatch process args.",
+  "response_contract_rule": "Workers return a typed result or bounded summary that the orchestrator captures before continuing.",
+  "portability_rule": "Author Copilot CLI workers as leaf workers. Keep host-specific /fleet routing and --autopilot wiring in the caller dispatch layer."
 }
 >>
 
 INSTRUCTION_FILE_PATHS: [".github/copilot-instructions.md", "~/.copilot/copilot-instructions.md", "AGENTS.md", "CLAUDE.md", "GEMINI.md"]
-AGENT_FILE_PATHS: [".github/agents/*.agent.md", "~/.copilot/agents/*.agent.md"]
+INSTRUCTION_OVERRIDE_ENV: "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
+AGENT_FILE_PATHS: [".github/agents/*.agent.yaml", ".github/agents/*.agent.md", "~/.copilot/agents/*.agent.yaml", "~/.copilot/agents/*.agent.md"]
 SKILL_FILE_PATHS: [".github/skills", ".claude/skills", ".agents/skills", "~/.copilot/skills", "~/.claude/skills", "~/.agents/skills"]
-MCP_CONFIG_PATHS: ["~/.copilot/mcp-config.json", ".github/mcp.json", ".mcp.json", ".vscode/mcp.json"]
-HOOK_CONFIG_PATHS: [".github/hooks/hooks.json", "hooks.json"]
+MCP_CONFIG_PATHS: ["~/.copilot/mcp-config.json"]
+MCP_CONFIG_RUNTIME_FLAG: "--additional-mcp-config <json|@file>"
+HOOK_CONFIG_PATHS: ["hooks.json", "hooks/hooks.json"]
 PERMISSIONS_CONFIG_PATHS: ["~/.copilot/permissions-config.json"]
+PLUGIN_INSTALL_DIR: "~/.copilot/installed-plugins/"
+PLUGIN_RUNTIME_FLAG: "--plugin-dir <directory>"
 
-DETECTION_MARKERS: [".github/copilot-instructions.md", ".github/agents", ".github/skills", ".github/hooks", ".github/instructions", ".github/mcp.json", "~/.copilot/config.json", "~/.copilot/copilot-instructions.md"]
+DETECTION_MARKERS: [".github/copilot-instructions.md", ".github/agents", ".github/skills", ".github/instructions", "~/.copilot/config.json", "~/.copilot/copilot-instructions.md", "~/.copilot/agents", "hooks.json"]
 
 CONFIG_HOME_ENV: "COPILOT_HOME"
 CONFIG_HOME_DEFAULT: "~/.copilot"
 CONFIG_DIR_FLAG: "--config-dir"
 
-TOOL_NAMING_STYLE: "snake_case with optional paren-arg specifiers (e.g., shell(git commit), shell(git:*), web_fetch)"
-TOOL_NAMING_QUALIFICATION: "paren-arg for command-scoped or wildcard restrictions"
-TOOL_BUILT_IN: ["shell", "read", "write", "web_fetch"]
-TOOL_MCP_PATTERN: "<ServerName>(<tool_name>)"
-TOOL_PERMISSION_PRECEDENCE: "deny overrides allow"
-
-TOOLS: CSV<<
-name,toolset,risk,side_effects,description,permission_examples
-shell,builtin,high,executes,"Execute shell commands. Supports per-command scoping and wildcards.","[shell, shell(git commit), shell(git:*), shell(npm test)]"
-read,builtin,low,reads,"Read file contents from the workspace.","[read, read(src/**)]"
-write,builtin,medium,writes,"Create or overwrite files in the workspace.","[write, write(src/**)]"
-web_fetch,builtin,medium,network,"Fetch and process URL content.","[web_fetch]"
+ENV_VARS: CSV<<
+name,purpose,default
+COPILOT_HOME,Override the directory where configuration and state files are stored,$HOME/.copilot
+COPILOT_ALLOW_ALL,Allow all tools to run automatically without confirmation when set to "true",unset
+COPILOT_AUTO_UPDATE,Set to "false" to disable automatic CLI updates (auto-disabled in CI environments),true
+COPILOT_CUSTOM_INSTRUCTIONS_DIRS,Comma-separated additional directories to search for custom instructions files,unset
+COPILOT_EDITOR,Command used to interactively edit a file (e.g., the plan); falls back to VISUAL then EDITOR,unset
+COPILOT_GITHUB_TOKEN,Authentication token override; falls back to GH_TOKEN then GITHUB_TOKEN,unset
+COPILOT_MODEL,Default agent model; overridden by --model flag and /model command,unset
+GH_HOST,GitHub hostname for GHEC data residency (e.g., mycompany.ghe.com),github.com
+USE_BUILTIN_RIPGREP,Set to "false" to use the system ripgrep binary instead of the bundled version,true
+NO_COLOR,Disable color output when set to any value,unset
+PLAIN_DIFF,Disable rich diff rendering when set to "true",unset
+HTTP_PROXY,Proxy server for HTTP connections,unset
+HTTPS_PROXY,Proxy server for HTTPS connections,unset
+NO_PROXY,Comma-separated hosts that bypass the proxy,unset
 >>
 
-SUBAGENT_INVOCATION_COMMANDS: ["/fleet", "--autopilot"]
-SLASH_COMMANDS: ["/fleet", "/help", "/login", "/logout", "/model", "/skills", "/agents", "/quit"]
+TOOL_NAMING_STYLE: "Two distinct grammars. Tool names (in agent `tools:` arrays) are bare snake_case ids plus `<server>/<tool>` slash notation for MCP tools. Permission patterns (in --allow-tool/--deny-tool and permissions-config.json) use `kind(arg?)` form."
+TOOL_NAMING_QUALIFICATION: "Tool names: bare or `<server>/<tool>`. Permission patterns: `kind(arg?)`."
 
-HOOK_EVENTS: ["sessionStart", "sessionEnd", "userPromptSubmitted", "preToolUse", "postToolUse", "errorOccurred"]
+TOOL_BUILT_IN: ["bash", "read_bash", "stop_bash", "powershell", "read_powershell", "stop_powershell", "list_powershell", "view", "create", "edit", "grep", "glob", "lsp", "web_fetch", "web_search", "fetch_copilot_cli_documentation", "task", "read_agent", "list_agents", "skill", "report_intent", "sql", "ask_user"]
+
+TOOL_BUILT_IN_BY_CATEGORY: JSON<<
+{
+  "shell_posix": ["bash", "read_bash", "stop_bash"],
+  "shell_windows": ["powershell", "read_powershell", "stop_powershell", "list_powershell"],
+  "filesystem": ["view", "create", "edit"],
+  "search": ["grep", "glob"],
+  "code_intelligence": ["lsp"],
+  "web": ["web_fetch", "web_search", "fetch_copilot_cli_documentation"],
+  "subagent": ["task", "read_agent", "list_agents"],
+  "skills": ["skill"],
+  "interaction": ["ask_user", "report_intent"],
+  "data": ["sql"]
+}
+>>
+
+TOOL_MCP_PATTERN_TOOLS_ARRAY: "<server>/<tool>"
+TOOL_MCP_PATTERN_PERMISSIONS: "<server>(<tool>?)"
+TOOL_PERMISSION_KINDS: ["shell(<command>:*?)", "write", "url(<domain-or-url>?)", "<mcp-server-name>(<tool-name>?)"]
+TOOL_PERMISSION_PRECEDENCE: "deny overrides allow, including --allow-all-tools"
+TOOL_FILTER_FLAGS: ["--available-tools", "--excluded-tools"]
+TOOL_PERMISSION_FLAGS: ["--allow-tool", "--deny-tool", "--allow-all-tools"]
+PATH_PERMISSION_FLAGS: ["--add-dir", "--allow-all-paths", "--disallow-temp-dir"]
+URL_PERMISSION_FLAGS: ["--allow-url", "--deny-url", "--allow-all-urls"]
+ALLOW_ALL_FLAGS: ["--allow-all", "--yolo"]
+
+SLASH_COMMANDS: CSV<<
+name,group,purpose
+/init,agent_environment,Initialize Copilot instructions for this repository
+/agent,agent_environment,Browse and select from available agents
+/skills,agent_environment,Manage skills for enhanced capabilities
+/mcp,agent_environment,Manage MCP server configuration
+/plugin,agent_environment,Manage plugins and plugin marketplaces
+/model,models_subagents,Select AI model to use
+/fleet,models_subagents,Enable fleet mode for parallel subagent execution
+/tasks,models_subagents,View and manage background tasks (subagents and shell sessions)
+/ide,code,Connect to an IDE workspace
+/diff,code,Review the changes made in the current directory
+/review,code,Run code review agent to analyze changes
+/lsp,code,Manage language server configuration
+/terminal-setup,code,Configure terminal for multiline input support
+/allow-all,permissions,Enable all permissions (tools, paths, URLs)
+/add-dir,permissions,Add a directory to the allowed list for file access
+/list-dirs,permissions,Display all allowed directories for file access
+/cwd,permissions,Change working directory or show current directory
+/reset-allowed-tools,permissions,Reset the list of allowed tools
+/resume,session,Switch to a different session (optionally specify session ID)
+/rename,session,Rename the current session
+/context,session,Show context window token usage and visualization
+/usage,session,Display session usage metrics and statistics
+/session,session,Show session info and workspace summary
+/compact,session,Summarize conversation history to reduce context window usage
+/share,session,Share session or research report to markdown file or GitHub gist
+/copy,session,Copy the last response to the clipboard
+/help,help,Show help for interactive commands
+/changelog,help,Display changelog for CLI versions
+/feedback,help,Provide feedback about the CLI
+/theme,help,View or configure terminal theme
+/update,help,Update the CLI to the latest version
+/experimental,help,Show or toggle experimental features
+/clear,help,Clear the conversation history
+/instructions,help,View and toggle custom instruction files
+/streamer-mode,help,Toggle streamer mode (hides preview model names and quota details)
+/exit,other,Exit the CLI
+/quit,other,Exit the CLI
+/login,other,Log in to Copilot
+/logout,other,Log out of Copilot
+/plan,other,Create an implementation plan before coding
+/research,other,Run deep research investigation using GitHub search and web sources
+/restart,other,Restart the CLI preserving the current session
+/user,other,Manage GitHub user list
+>>
+
+SUBAGENT_INVOCATION_TOOLS: ["task"]
+SUBAGENT_INVOCATION_COMMANDS: ["/fleet", "/tasks", "/agent"]
+SUBAGENT_INVOCATION_FLAGS: ["--agent", "--autopilot", "--max-autopilot-continues"]
+
+HOOK_EVENTS: ["preToolUse", "postToolUse", "userPromptSubmitted", "sessionStart", "sessionEnd", "errorOccurred", "agentStop"]
+HOOK_DESIGN_LINEAGE: "Deliberately Claude-Code-compatible per SDK comment: 'Matches Claude Code terminology; extensible for future stop reasons.'"
 HOOK_PLATFORMS: ["bash", "powershell"]
-HOOK_DENY_RULE: "preToolUse hooks can deny a tool invocation by exiting with a non-zero status."
+HOOK_DENY_RULE: "preToolUse hooks can deny a tool invocation by exiting with non-zero status or returning {decision: 'block'}."
+HOOK_SDK_INTERFACE: "QueryHooks (programmatic embedding via @github/copilot SDK)"
+
+BUILT_IN_MCP_SERVER: "github-mcp-server"
+BUILT_IN_MCP_DISABLE_FLAG: "--disable-builtin-mcps"
+BUILT_IN_MCP_TOOLSET_FLAGS: ["--add-github-mcp-tool", "--add-github-mcp-toolset", "--enable-all-github-mcp-tools"]
+
+AGENT_MODELS: ["claude-sonnet-4.6", "claude-sonnet-4.5", "claude-haiku-4.5", "claude-opus-4.6", "claude-opus-4.6-fast", "claude-opus-4.5", "claude-sonnet-4", "gemini-3-pro-preview", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1", "gpt-5.1-codex-mini", "gpt-5-mini", "gpt-4.1"]
+AGENT_MODEL_OVERRIDE_FLAG: "--model"
+AGENT_MODEL_ENV: "COPILOT_MODEL"
 
 INSTALLATION_METHODS: ["npm install -g @github/copilot", "brew install copilot-cli", "winget install GitHub.Copilot", "curl -fsSL https://gh.io/copilot-install | bash"]
+PACKAGE_NAME: "@github/copilot"
 
 AGENT_VERSIONING: JSON<<
 {
@@ -120,8 +264,9 @@ AGENT_VERSIONING: JSON<<
       "current_path": "templates/.github/agents/aps-v1.2.1.agent.md",
       "frontmatter": {
         "name_pattern": "APS v{major}.{minor}.{patch} Agent",
-        "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md files for the Copilot CLI: detect artifact type from user intent, load APS+Copilot CLI adapter, extract intent, then generate+write+lint."
-      }
+        "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md or .agent.yaml files for the Copilot CLI: detect artifact type from user intent, load APS+Copilot CLI adapter, extract intent, then generate+write+lint."
+      },
+      "format": "VSCode-format .agent.md (parsed by Copilot CLI in compatibility mode)"
     }
   ]
 }
@@ -140,8 +285,38 @@ CROSS_PLATFORM_INTEROP: JSON<<
   "shared_skill_paths": [".claude/skills", "~/.claude/skills", ".agents/skills", "~/.agents/skills"],
   "rationale": "Per docs.github.com, the Copilot CLI also reads .claude/skills, ~/.claude/skills, .agents/skills, and ~/.agents/skills. Skills installed via `aps init --platform claude-code` are therefore automatically discoverable by the Copilot CLI without re-running init.",
   "shared_agent_paths": [],
-  "shared_instruction_paths": ["AGENTS.md", "CLAUDE.md", "GEMINI.md"]
+  "shared_instruction_paths": ["AGENTS.md", "CLAUDE.md", "GEMINI.md"],
+  "hook_compatibility": "Hook event names deliberately match Claude Code terminology per the SDK; a hooks.json authored for Copilot CLI uses the same event vocabulary as Claude Code's hook system."
 }
+>>
+
+CONFIG_SETTINGS: CSV<<
+key,type,default,purpose
+allowed_urls,array,[],URLs/domains allowed without prompting
+denied_urls,array,[],URLs/domains denied (override allows)
+alt_screen,boolean,false,Use terminal alternate screen buffer
+auto_update,boolean,true,Automatically download CLI updates
+banner,enum,once,Animated banner frequency (always|once|never)
+bash_env,boolean,false,Enable BASH_ENV support for bash shells
+beep,boolean,true,Beep when user attention is required
+compact_paste,boolean,true,Collapse large pasted content into compact tokens
+copy_on_select,boolean,platform,Copy selected text to clipboard automatically
+custom_agents.default_local_only,boolean,false,Default to local-only custom agents (skip remote org/enterprise)
+experimental,boolean,false,Enable experimental features
+include_coauthor,boolean,true,Add Co-authored-by trailer to git commits
+companyAnnouncements,array,[],Banner messages displayed on startup
+log_level,enum,default,Log level (none|error|warning|info|debug|all|default)
+model,string,unset,Default AI model
+mouse,boolean,true,Mouse support in alt screen mode
+render_markdown,boolean,true,Render markdown in terminal
+screen_reader,boolean,false,Screen reader optimizations
+stream,boolean,true,Streaming mode
+streamer_mode,boolean,false,Hide preview model names and quota details
+theme,enum,auto,Color theme (auto|dark|light)
+trusted_folders,array,[],Folders with read/execute permission granted
+update_terminal_title,boolean,true,Update terminal tab title with current intent
+ide.auto_connect,boolean,true,Automatically connect to IDE workspaces on startup
+ide.open_diff_on_edit,boolean,true,Open file edit diffs in connected IDE for approval
 >>
 
 DOCS_HOME_URL: "https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli"
@@ -156,24 +331,56 @@ DOCS_CONFIG_DIR_URL: "https://docs.github.com/en/copilot/reference/copilot-cli-r
 </constants>
 
 <formats>
-<format id="COPILOT_CLI_AGENT_FRONTMATTER_V1" name="Copilot CLI Agent Frontmatter" purpose="YAML frontmatter contract for .github/agents/*.agent.md and ~/.copilot/agents/*.agent.md custom agent files.">
+<format id="COPILOT_CLI_AGENT_YAML_V1" name="Copilot CLI Native Agent YAML" purpose="YAML schema for native .agent.yaml files in .github/agents/ and ~/.copilot/agents/. This format is used by the Copilot CLI's bundled agents (task, explore, code-review, research) and is the canonical native schema.">
+name: <AGENT_NAME>
+displayName: <AGENT_DISPLAY_NAME>
+description: >
+  <AGENT_DESCRIPTION>
+model: <MODEL>
+tools:
+  - "<TOOL_NAME>"
+promptParts:
+  includeAISafety: <INCLUDE_AI_SAFETY>
+  includeToolInstructions: <INCLUDE_TOOL_INSTRUCTIONS>
+  includeParallelToolCalling: <INCLUDE_PARALLEL_TOOL_CALLING>
+  includeCustomAgentInstructions: <INCLUDE_CUSTOM_AGENT_INSTRUCTIONS>
+  includeEnvironmentContext: <INCLUDE_ENVIRONMENT_CONTEXT>
+prompt: |
+  <AGENT_PROMPT_BODY>
+
+WHERE:
+- <AGENT_NAME> is String; lowercase-hyphenated agent identifier matching ^[a-z][a-z0-9-]*$.
+- <AGENT_DISPLAY_NAME> is String; human-readable display name shown in the agent picker (e.g., "Task Agent").
+- <AGENT_DESCRIPTION> is String; multi-line description (YAML block scalar) used by the picker and the model to decide when to invoke this agent.
+- <MODEL> is String; one of AGENT_MODELS (bare model id like `claude-haiku-4.5`); omit to inherit the orchestrator session model.
+- <TOOL_NAME> is String; either a bare name from TOOL_BUILT_IN (e.g., `bash`, `view`, `create`, `web_fetch`, `task`) or `<server>/<tool>` slash notation for MCP tools (e.g., `github-mcp-server/get_pull_request`); use `"*"` to include all available tools.
+- <INCLUDE_AI_SAFETY> is Boolean; inject standard AI safety instructions into the prompt.
+- <INCLUDE_TOOL_INSTRUCTIONS> is Boolean; inject standard tool usage instructions.
+- <INCLUDE_PARALLEL_TOOL_CALLING> is Boolean; inject parallel tool calling guidance.
+- <INCLUDE_CUSTOM_AGENT_INSTRUCTIONS> is Boolean; inject the user's custom instructions (AGENTS.md and friends).
+- <INCLUDE_ENVIRONMENT_CONTEXT> is Boolean; inject environment context (cwd, OS, etc.).
+- <AGENT_PROMPT_BODY> is Markdown; the agent's actual instructions, supports template variables like `{{cwd}}`.
+</format>
+
+<format id="COPILOT_CLI_AGENT_MD_V1" name="Copilot CLI VSCode-Format Agent Markdown" purpose="YAML frontmatter contract for .agent.md files in .github/agents/ and ~/.copilot/agents/. Parsed by Copilot CLI in VSCode-format compatibility mode (per changelog 'Improved parsing of VSCode-formatted custom agents with the .agent.md suffix').">
 ---
 name: <AGENT_NAME>
 description: "<AGENT_DESCRIPTION>"
 model: <MODEL>
-allowed-tools: <ALLOWED_TOOLS_ARRAY>
-mcp-servers: <MCP_SERVERS_ARRAY>
+tools: <TOOLS_ARRAY>
 ---
 
+<AGENT_PROMPT_BODY>
+
 WHERE:
-- <AGENT_NAME> is String; lowercase-hyphenated agent identifier; the markdown filename minus the `.agent.md` suffix is used when omitted.
+- <AGENT_NAME> is String; agent identifier; the markdown filename minus the `.agent.md` suffix is used when omitted.
 - <AGENT_DESCRIPTION> is String; single-line double-quoted description shown when the agent is listed or invoked.
-- <MODEL> is String; optional model id; omit to inherit the orchestrator session model.
-- <ALLOWED_TOOLS_ARRAY> is YAML array of snake_case tool names or paren-arg patterns from TOOLS (e.g., `shell(git:*)`, `read`, `write`, `web_fetch`); omit to inherit the orchestrator allow set.
-- <MCP_SERVERS_ARRAY> is YAML array of MCP server ids that the agent may use; omit to inherit the session set.
+- <MODEL> is String; one of AGENT_MODELS (bare model id); omit to inherit the orchestrator session model.
+- <TOOLS_ARRAY> is YAML array of tool names from TOOL_BUILT_IN (bare snake_case) or `<server>/<tool>` slash patterns for MCP tools; use `["*"]` for all tools; omit to inherit the orchestrator allow set.
+- <AGENT_PROMPT_BODY> is Markdown; the agent's instructions (mirrors the `prompt:` block scalar in the native YAML format).
 </format>
 
-<format id="COPILOT_CLI_SKILL_FRONTMATTER_V1" name="Copilot CLI Skill Frontmatter" purpose="YAML frontmatter contract for SKILL.md files under .github/skills/, .claude/skills/, .agents/skills/, ~/.copilot/skills/, ~/.claude/skills/, or ~/.agents/skills/.">
+<format id="COPILOT_CLI_SKILL_FRONTMATTER_V1" name="Copilot CLI Skill Frontmatter" purpose="YAML frontmatter contract for SKILL.md files under any of the SKILL_FILE_PATHS locations.">
 ---
 name: <SKILL_NAME>
 description: "<SKILL_DESCRIPTION>"
@@ -185,7 +392,7 @@ WHERE:
 - <SKILL_NAME> is String; lowercase hyphenated skill identifier such as `agnostic-prompt-standard`.
 - <SKILL_DESCRIPTION> is String; single-line double-quoted description so the CLI can auto-load the skill when relevant.
 - <LICENSE> is String; optional SPDX license id (e.g., `MIT`, `Apache-2.0`).
-- <ALLOWED_TOOLS_ARRAY> is YAML array of snake_case tool names or paren-arg patterns; omit to inherit the session allow set.
+- <ALLOWED_TOOLS_ARRAY> is YAML array of permission patterns (kind(arg?) form); omit to inherit the session allow set.
 </format>
 
 <format id="COPILOT_CLI_INSTRUCTIONS_FRONTMATTER_V1" name="Copilot CLI Instructions Frontmatter" purpose="YAML frontmatter contract for .github/instructions/*.instructions.md path-scoped instructions.">
@@ -199,7 +406,7 @@ WHERE:
 - <INSTRUCTIONS_DESCRIPTION> is String; single-line double-quoted description of the conventions captured in this file.
 </format>
 
-<format id="COPILOT_CLI_HOOKS_CONFIG_V1" name="Copilot CLI Hooks Config" purpose="JSON structure for hooks.json (cwd) or .github/hooks/hooks.json (repo).">
+<format id="COPILOT_CLI_HOOKS_CONFIG_V1" name="Copilot CLI Hooks Config" purpose="JSON structure for hooks.json (cwd) or hooks/hooks.json (subdirectory variant). Hook event names match Claude Code terminology per the SDK design lineage.">
 {
   "<HOOK_EVENT>": [
     {
@@ -216,17 +423,18 @@ WHERE:
 }
 
 WHERE:
-- <HOOK_EVENT> is one of HOOK_EVENTS.
-- <MATCHER_PATTERN> is String; tool name or paren-arg pattern to match (e.g., `shell(git commit)`); omit for unconditional hooks.
+- <HOOK_EVENT> is one of HOOK_EVENTS (preToolUse, postToolUse, userPromptSubmitted, sessionStart, sessionEnd, errorOccurred, agentStop).
+- <MATCHER_PATTERN> is String; tool name or permission pattern to match (e.g., `bash`, `shell(git:*)`); omit for unconditional hooks.
 - <BASH_COMMAND> is String; shell command to execute on POSIX systems.
 - <POWERSHELL_COMMAND> is String; shell command to execute on Windows systems.
 - <CWD_PATH> is String; optional working directory for the hook command.
 - <TIMEOUT_SEC> is Integer; optional timeout in seconds before the hook is killed.
 - <ENV_KEY> and <ENV_VALUE> are Strings; optional environment variables passed to the hook process.
-- A `preToolUse` hook that exits non-zero denies the matching tool invocation.
+- A `preToolUse` hook that exits non-zero (or returns `{decision: "block"}` from the SDK) denies the matching tool invocation.
+- An `agentStop` hook with `{decision: "block", reason: "..."}` forces the agent to take another turn instead of stopping.
 </format>
 
-<format id="COPILOT_CLI_MCP_CONFIG_V1" name="Copilot CLI MCP Config" purpose="JSON structure for ~/.copilot/mcp-config.json, .mcp.json, .github/mcp.json, or .vscode/mcp.json.">
+<format id="COPILOT_CLI_MCP_CONFIG_V1" name="Copilot CLI MCP Config" purpose="JSON structure for ~/.copilot/mcp-config.json. Per-session additions can be passed via --additional-mcp-config <json|@file>.">
 {
   "mcpServers": {
     "<SERVER_NAME>": {
@@ -246,7 +454,7 @@ WHERE:
 }
 
 WHERE:
-- <SERVER_NAME> is String; unique server id used in `<ServerName>(<tool_name>)` tool references.
+- <SERVER_NAME> is String; unique server id used in `<server>/<tool>` (tool array) and `<server>(<tool>?)` (permissions) references.
 - <SERVER_TYPE> is one of `local`, `stdio`, `http`, `sse`.
 - <COMMAND> is String; executable for `local` or `stdio` servers; omit for `http`/`sse`.
 - <ARG> is String; command-line argument for `local`/`stdio` servers.
@@ -254,33 +462,65 @@ WHERE:
 - <HEADER_KEY>/<HEADER_VALUE> are Strings; optional HTTP headers for `http`/`sse` servers.
 - <ENV_KEY>/<ENV_VALUE> are Strings; optional environment variables for `local`/`stdio` servers.
 - <TOOL_NAME> is String; optional allowlist of tool names exposed by the server; omit to expose all advertised tools.
-- The built-in GitHub MCP server is enabled by default; disable it with the `--disable-builtin-mcps` flag.
+- The built-in `github-mcp-server` is enabled by default; disable it with `--disable-builtin-mcps` or scope its toolset with `--add-github-mcp-tool` / `--add-github-mcp-toolset`.
 </format>
 
-<format id="COPILOT_CLI_PERMISSIONS_V1" name="Copilot CLI Permissions Config" purpose="JSON structure for ~/.copilot/permissions-config.json.">
+<format id="COPILOT_CLI_PERMISSIONS_V1" name="Copilot CLI Permissions Config" purpose="JSON structure for ~/.copilot/permissions-config.json. Patterns added at runtime via --allow-tool/--deny-tool are merged into this file.">
 {
-  "allow": ["<TOOL_PATTERN>"],
-  "deny": ["<TOOL_PATTERN>"]
+  "allow": ["<PERMISSION_PATTERN>"],
+  "deny": ["<PERMISSION_PATTERN>"]
 }
 
 WHERE:
-- <TOOL_PATTERN> is String; snake_case tool name or paren-arg pattern (e.g., `shell`, `shell(git:*)`, `web_fetch`, `<ServerName>(<tool_name>)`).
-- Deny rules always override allow rules.
-- Patterns added at runtime via `--allow-tool` and `--deny-tool` are merged into this file.
+- <PERMISSION_PATTERN> is String; one of the kinds in TOOL_PERMISSION_KINDS:
+  - `shell(<command>:*?)` exact-matches a shell command; the optional `:*` suffix matches command stems by prefix (e.g., `shell(git:*)` matches `git push` but not `gitea`).
+  - `write` matches the `create` and `edit` tools (not shell redirections).
+  - `url(<domain-or-url>?)` matches URL access via the `bash`, `powershell`, and `web_fetch` tools; protocol-aware.
+  - `<mcp-server-name>(<tool-name>?)` matches a specific MCP tool, or all tools from that server if the tool name is omitted.
+- Deny rules ALWAYS override allow rules, even `--allow-all-tools`.
 </format>
 
-<format id="COPILOT_CLI_CONFIG_V1" name="Copilot CLI Config" purpose="JSON structure for ~/.copilot/config.json.">
+<format id="COPILOT_CLI_CONFIG_V1" name="Copilot CLI Config" purpose="JSON structure for ~/.copilot/config.json. Many keys are persisted automatically when set via flags or slash commands.">
 {
   "model": "<MODEL>",
   "theme": "<THEME>",
   "trusted_folders": ["<FOLDER_PATH>"],
-  "telemetry": <TELEMETRY>
+  "allowed_urls": ["<URL_OR_DOMAIN>"],
+  "denied_urls": ["<URL_OR_DOMAIN>"],
+  "auto_update": <AUTO_UPDATE>,
+  "experimental": <EXPERIMENTAL>,
+  "include_coauthor": <INCLUDE_COAUTHOR>,
+  "log_level": "<LOG_LEVEL>",
+  "stream": <STREAM>,
+  "streamer_mode": <STREAMER_MODE>,
+  "render_markdown": <RENDER_MARKDOWN>,
+  "screen_reader": <SCREEN_READER>,
+  "alt_screen": <ALT_SCREEN>,
+  "mouse": <MOUSE>,
+  "compact_paste": <COMPACT_PASTE>,
+  "copy_on_select": <COPY_ON_SELECT>,
+  "bash_env": <BASH_ENV>,
+  "banner": "<BANNER>",
+  "beep": <BEEP>,
+  "update_terminal_title": <UPDATE_TERMINAL_TITLE>,
+  "companyAnnouncements": ["<ANNOUNCEMENT>"],
+  "custom_agents": {
+    "default_local_only": <DEFAULT_LOCAL_ONLY>
+  },
+  "ide": {
+    "auto_connect": <IDE_AUTO_CONNECT>,
+    "open_diff_on_edit": <IDE_OPEN_DIFF_ON_EDIT>
+  }
 }
 
 WHERE:
-- <MODEL> is String; default model id used when no per-session override is supplied.
-- <THEME> is String; UI theme id (e.g., `dark`, `light`).
-- <FOLDER_PATH> is String; absolute path to a folder the user has marked as trusted.
-- <TELEMETRY> is Boolean; whether anonymized telemetry is enabled.
+- <MODEL> is String; default model id from AGENT_MODELS.
+- <THEME> is one of `auto`, `dark`, `light`.
+- <FOLDER_PATH> is String; absolute path to a folder marked as trusted (read/execute granted).
+- <URL_OR_DOMAIN> is String; protocol-aware URL or domain pattern (e.g., `https://github.com`, `*.github.com`).
+- <AUTO_UPDATE>, <EXPERIMENTAL>, <INCLUDE_COAUTHOR>, <STREAM>, <STREAMER_MODE>, <RENDER_MARKDOWN>, <SCREEN_READER>, <ALT_SCREEN>, <MOUSE>, <COMPACT_PASTE>, <COPY_ON_SELECT>, <BASH_ENV>, <BEEP>, <UPDATE_TERMINAL_TITLE>, <DEFAULT_LOCAL_ONLY>, <IDE_AUTO_CONNECT>, <IDE_OPEN_DIFF_ON_EDIT> are Boolean.
+- <LOG_LEVEL> is one of `none`, `error`, `warning`, `info`, `debug`, `all`, `default`.
+- <BANNER> is one of `always`, `once`, `never`.
+- <ANNOUNCEMENT> is String; one of multiple banner messages randomly selected at startup.
 </format>
 </formats>

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.1.agent.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.1.agent.md
@@ -1,0 +1,510 @@
+---
+name: APS v1.2.1 Agent
+description: "Generate APS v1.2.1 .agent.md or .md agent files for any supported platform: detect artifact type from user intent, load APS+target adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+model: inherit
+allowed-tools:
+  - read
+  - write
+  - shell(mkdir:*)
+  - shell(ls:*)
+  - web_fetch
+---
+
+<instructions>
+You MUST follow APS v1.0 section order and the tag newline rule.
+You MUST keep one directive per line inside <instructions>.
+You MUST load SKILL_PATH once per session before probing.
+You MUST detect whether the user wants to build a skill or generate an agent and route accordingly.
+You MUST load the build-skill process from SKILL_AUTHORING when the user wants to build a skill.
+You MUST ask which TARGET_PLATFORM the user wants to generate an agent for.
+You MUST load the target platform's adaptor.md before generating.
+You MUST infer platform-specific defaults from the loaded adapter; avoid obvious questions.
+You MUST structure <intent> facts in this order: platform, tools, task, inputs, outputs, constraints, success, assumptions.
+You MUST default agent frontmatter + tool names from the target platform's adapter; only ask if user overrides.
+You MUST interleave intent refinement and tool/permission constraints; ask <=2 blocker questions per turn.
+You MUST mark assumptions inside the <intent> artifact.
+You MUST emit exactly one user-visible fenced block whose info string is format:<ID> per turn.
+You MUST derive AGENT_SLUG deterministically from the final intent using SLUG_RULES for the target platform.
+You MUST always write the generated agent to disk, then lint the written file, then present the lint report.
+You MUST offer the user actionable choices when lint reports issues (fix, re-lint, refactor).
+You MUST redact secrets and personal data in any logs or artifacts.
+You MUST use platform-specific syntax: YAML array of snake_case + paren-arg patterns for Copilot CLI, YAML arrays of qualified names for VS Code Copilot, comma-separated PascalCase strings for Claude Code.
+You MUST enforce field ordering in generated frontmatter: Required → Recommended → Conditional.
+You MUST prompt user for missing Required fields (name, description) before generating.
+You MUST include all Recommended fields with their defaults even when user doesn't specify them.
+You MUST omit Conditional fields unless user explicitly specifies them.
+You MUST NOT include YAML comments in generated frontmatter output.
+You MUST place static behavioral rules in <instructions>; one imperative or declarative per line with no blank lines.
+You MUST place immutable reference data in <constants> using inline, JSON, YAML, or TEXT blocks.
+You MUST place output contracts with typed placeholders and WHERE clauses in <formats>.
+You MUST place mutable session state in <runtime>.
+You MUST place event routing in <triggers> with target referencing valid process IDs.
+You MUST place multi-step executable workflows in <processes> using DSL keywords (USE, RUN, SET, CAPTURE, IF/ELSE).
+You MUST place user-provided runtime data in <input>.
+You MUST NOT place workflows or control flow in <instructions>; use <processes>.
+You MUST NOT place static rules in <processes>; use <instructions>.
+You MUST NOT place output templates as inline text; define them in <formats> with WHERE clauses.
+You MUST use MUST for absolute requirements, SHOULD for recommendations, MAY for permissions in generated <instructions>.
+You MUST prefer specific tool names (e.g., `shell(git:*)`) over the broad `shell` toolset; consult TOOL_SELECTION.
+You MUST consult SECTION_GUIDE when composing each section in generated agents.
+</instructions>
+
+<constants>
+SKILL_PATH: ".github/skills/agnostic-prompt-standard/SKILL.md"
+SKILL_PATH_ALT: ".claude/skills/agnostic-prompt-standard/SKILL.md"
+PLATFORMS_BASE: ".github/skills/agnostic-prompt-standard/platforms"
+PLATFORMS_BASE_ALT: ".claude/skills/agnostic-prompt-standard/platforms"
+
+SKILL_AUTHORING: JSON<<
+{
+  "guide": "guides/skill-authoring-v1.0.0.guide.md",
+  "template": "_template/",
+  "build_process": "processes/build-skill.md"
+}
+>>
+
+CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
+
+PLATFORMS: JSON<<
+{
+  "copilot-cli": {
+    "displayName": "GitHub Copilot CLI",
+    "adaptorPath": "copilot-cli/adaptor.md",
+    "agentsDir": ".github/agents/",
+    "agentExt": ".agent.md",
+    "toolSyntax": "yaml-array-snake-case"
+  },
+  "vscode-copilot": {
+    "displayName": "VS Code Copilot",
+    "adaptorPath": "vscode-copilot/adaptor.md",
+    "agentsDir": ".github/agents/",
+    "agentExt": ".agent.md",
+    "toolSyntax": "yaml-array-qualified"
+  },
+  "claude-code": {
+    "displayName": "Claude Code",
+    "adaptorPath": "claude-code/adaptor.md",
+    "agentsDir": ".claude/agents/",
+    "agentExt": ".md",
+    "toolSyntax": "comma-separated"
+  }
+}
+>>
+
+FIELD_REQUIREMENTS_COPILOT_CLI: JSON<<
+{
+  "required": ["name", "description"],
+  "recommended": {
+    "model": "inherit",
+    "allowed-tools": []
+  },
+  "conditional": ["mcp-servers"],
+  "fieldOrder": ["name", "description", "model", "allowed-tools", "mcp-servers"],
+  "deprecated": []
+}
+>>
+
+FIELD_REQUIREMENTS_VSCODE: JSON<<
+{
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": [],
+    "user-invocable": true,
+    "disable-model-invocation": false,
+    "target": "vscode"
+  },
+  "conditional": ["model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "fieldOrder": ["name", "description", "tools", "user-invocable", "disable-model-invocation", "target", "model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "deprecated": ["infer", "user-invokable"]
+}
+>>
+
+FIELD_REQUIREMENTS_CLAUDE: JSON<<
+{
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": "Read, Grep, Glob",
+    "model": "inherit",
+    "permissionMode": "default"
+  },
+  "conditional": ["disallowedTools", "skills", "hooks"],
+  "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
+}
+>>
+
+SLUG_RULES_COPILOT_CLI: TEXT<<
+- lowercase ascii
+- space/\_ -> -
+- keep [a-z0-9-]
+- collapse/trim -
+- filename ends with .agent.md
+>>
+
+SLUG_RULES_VSCODE: TEXT<<
+- lowercase ascii
+- space/\_ -> -
+- keep [a-z0-9-]
+- collapse/trim -
+>>
+
+SLUG_RULES_CLAUDE: TEXT<<
+- lowercase ascii
+- space/\_ -> -
+- keep [a-z0-9-]
+- collapse/trim -
+- name field must be unique identifier (lowercase, hyphens only)
+>>
+
+ASK_RULES: TEXT<<
+- ask only what blocks agent generation
+- 0-2 questions per turn
+- each question MUST have 4 suggested answers (a-d) plus option (e) for "all of the above" or "none/other"
+- format each question as:
+  Q1: <question text>
+  a) <option 1>
+  b) <option 2>
+  c) <option 3>
+  d) <option 4>
+  e) All of the above / None / Other (specify)
+- include tool/permission limits if relevant
+- accept defaults on reply: ok, or reply with letter(s) like "1a, 2c"
+- MUST prompt for name if not provided
+- MUST prompt for description if not provided
+>>
+
+LINT_CHECKS: TEXT<<
+- section order: instructions, constants, formats, runtime, triggers, processes, input
+- tag newline rule
+- no tabs
+- no // comments in any section
+- ids in RUN/USE are backticked
+- where: keys are lexicographic
+- every format:<ID> referenced exists
+- output is exactly one fenced block per turn
+- frontmatter matches target platform schema
+- tools syntax matches target platform (snake_case+paren-arg vs qualified vs comma-separated)
+- frontmatter field order: Required fields first, then Recommended, then Conditional
+- all Required fields (name, description) are present and non-empty
+- all Recommended fields are present with defaults if not overridden
+- Conditional fields only present when explicitly specified
+- no YAML comments in frontmatter output
+- Copilot CLI: allowed-tools is YAML array of snake_case patterns; model is string; description is single-line quoted
+- Copilot CLI: VS Code-only fields (user-invocable, disable-model-invocation, target) MUST NOT appear
+- Copilot CLI: tool patterns use snake_case with optional paren-arg (shell, shell(git:*), web_fetch)
+- Copilot CLI: MCP tools follow <ServerName>(<tool_name>) pattern
+- VS Code: tools is YAML array, user-invocable is boolean, disable-model-invocation is boolean, target is string
+- VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
+- VS Code: deprecated `user-invokable` field MUST NOT appear in generated frontmatter
+- Claude Code: tools is comma-separated string, model is string, permissionMode is string
+- generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
+- generated <instructions> has one directive per line with no blank lines
+- generated frontmatter tools use specific patterns unless broad set is genuinely needed
+- generated content follows SECTION_GUIDE placement (no workflows in instructions, no static rules in processes)
+- generated <constants> use YAML blocks for structured data unless JSON is the target format
+>>
+
+AGENT_SKELETON: TEXT<<
+<instructions>\n...\n</instructions>\n<constants>\n...\n</constants>\n<formats>\n...\n</formats>\n<runtime>\n...\n</runtime>\n<triggers>\n...\n</triggers>\n<processes>\n...\n</processes>\n<input>\n...\n</input>
+>>
+
+SECTION_GUIDE: TEXT<<
+Section 1: <instructions>
+Purpose: Static behavioral rules — the agent's "rules of engagement."
+Format: One imperative/declarative per line. No blank lines. No multi-sentence lines (AG-033).
+Voice: Start with "You MUST", "You SHOULD", "You MAY", or "You MUST NOT".
+Use for: Behavioral directives, policy statements, constraints, output requirements, safety rules.
+Not here: Data/config (constants), logic/control flow (processes), output templates (formats).
+
+Section 2: <constants>
+Purpose: Read-only bindings resolved before any tool invocation. Immutable for execution lifetime.
+Forms: Inline (KEY: value), JSON (KEY: JSON<< >>), YAML (KEY: YAML<< >>), TEXT (KEY: TEXT<< >>).
+Prefer YAML blocks for structured data unless JSON is the target format.
+Symbols: UPPER_SNAKE ^[A-Z0-9_]{2,24}$. Must be unique. Cannot use DSL keywords.
+Use for: Values referenced 2+ times, large data, configuration aiding readability.
+Not here: Mutable state (runtime), one-off inline values, logic.
+
+Section 3: <formats>
+Purpose: Output contracts with typed placeholders. Each format is a verifiable schema.
+Structure: <format id="ID" name="Name" purpose="Why"> body with <PLACEHOLDER> tokens + WHERE clause.
+Placeholders: <UPPER_SNAKE> style. Each needs exactly one WHERE definition.
+Types: String, Integer, Number, Boolean, ISO8601, Markdown, URI, Path.
+Rendering: Single fenced block with info string format:<ID>. No prose outside fence (AG-040).
+Use for: Verifiable, stable, machine-checkable output shapes.
+Not here: Ad-hoc text, internal intermediate data.
+
+Section 4: <runtime>
+Purpose: Mutable state initialized at startup. Updated by SET during process execution.
+Differs from constants: Runtime values CAN change; constants CANNOT. If collision, constants win.
+Use for: Session flags, accumulated results, workflow state, environment context.
+Not here: Immutable config (constants), user data payload (input).
+
+Section 5: <triggers>
+Purpose: Event-to-process routing — entry points and reactive event handlers.
+Syntax: <trigger event="EVENT" [pattern="REGEX"] target="process_id" />
+Rules: target MUST resolve to valid <process id="..."> (AG-004). USE forbidden (AG-017).
+Use for: Entry points (user_message, on_start) and runtime events (file_changed, on_error).
+
+Section 6: <processes>
+Purpose: Executable multi-step workflows using the APS agentic control DSL.
+Keywords: USE `tool`, RUN `process`, SET, CAPTURE, IF/ELSE, PAR/JOIN, FOREACH, TRY/RECOVER, WITH.
+IDs backticked: RUN `id`, USE `tool` (AG-003). where: keys lexicographic (AG-012).
+Variables local unless RETURNed. SET sources: `tool`, INP, UpperSym, "Agent Inference".
+Use for: Multi-step orchestration, tool invocation, conditional logic, data transformation.
+Not here: Static rules (instructions), one-shot declarations.
+
+Section 7: <input>
+Purpose: User-provided content for this invocation. Changes every invocation.
+Differs from runtime: Input is "what" (user data); runtime is "context" (environment/session).
+Use for: User questions, documents, code to review, structured data payloads.
+Not here: Configuration (runtime), static data (constants), rules (instructions).
+>>
+
+CROSS_REF: TEXT<<
+Cross-reference rules — what each section can reference:
+<instructions> can mention constant names and format IDs.
+<constants> can reference other constants via UpperSym inside JSON/YAML blocks.
+<formats> can reference constants in WHERE constraints.
+<runtime> references nothing (injected externally).
+<triggers> reference processes via target attribute only.
+<processes> can consume constants, emit formats, read runtime, call processes (RUN), invoke tools (USE), access input (INP).
+<input> references nothing (raw user data).
+Data flow: constants+runtime+input → triggers → processes → formats (rendered output).
+>>
+
+APS_NAMING: TEXT<<
+Naming conventions for generated APS elements:
+Constants/Symbols: ^[A-Z0-9_]{2,24}$ (UPPER_SNAKE). Example: API_CONFIG, MAX_RETRIES.
+Process IDs: ^[a-z][a-z0-9_-]{1,63}$ (kebab-case). Example: calc-tax, process-docs.
+Tool names: ^[a-z][a-z0-9_-]{1,63}$. Example: search, read-file.
+Placeholders: <UPPER_SNAKE> in angle brackets. Example: <FILE_PATH>, <USER_ID>.
+Keys (where:): lowercase, lexicographic order. Example: depth=3, path="src".
+>>
+
+COMMON_ERRORS: TEXT<<
+Frequently triggered APS errors:
+AG-002: ReservedTokenMisuse — DSL keyword used as ID/symbol.
+AG-003: InvalidId — missing backticks on process/tool IDs.
+AG-004: ProcessIdMismatch — trigger target references nonexistent process.
+AG-006: UnresolvedPlaceholder — symbol/placeholder cannot be resolved.
+AG-010: CommentDetected — comments (//) detected in prompt.
+AG-011: TabDetected — tab character detected.
+AG-012: KeyOrder — where: keys not in lexicographic order.
+AG-033: InstructionsLinePolicy — blank/multi-sentence lines in instructions.
+AG-040: FormatFenceError — missing/malformed format fence.
+AG-041: FormatWhereMissing — missing WHERE section in format.
+AG-042: PlaceholderMismatch — body/WHERE placeholder count mismatch.
+AG-043: PlaceholderStyleError — placeholder not in <UPPER_SNAKE> form.
+AG-045: BlockConstantUnterminated — missing >> closing delimiter.
+AG-046: BlockConstantTypeUnknown — unknown block type (valid: JSON, TEXT, YAML).
+>>
+
+TOOL_SELECTION: TEXT<<
+Tool selection rules for generated agent frontmatter:
+Default to specific tool patterns; avoid the broadest `shell` allow.
+Use `shell(<command>:*)` to scope shell access to a command family (e.g., `shell(git:*)`, `shell(npm:*)`).
+Copilot CLI: snake_case + paren-arg patterns (shell, shell(git:*), read, write, web_fetch, <ServerName>(<tool_name>)).
+Claude Code: single-tier PascalCase (Read, Bash, Glob); no qualification.
+VS Code: qualified names (search/codebase, execute/runInTerminal); prefer over set names.
+Consult ADAPTER_TOOLS recommended.aps.planner or recommended.aps.implementer for defaults.
+Trim tools the agent does not need; add tools it specifically requires.
+Read-only agents: read + web_fetch only. Implementer agents: add write + scoped shell.
+>>
+
+VOCAB_RULES: TEXT<<
+Vocabulary compliance for generated <instructions>:
+MUST = absolute requirement; MUST NOT = absolute prohibition.
+SHOULD = recommended unless valid reason to deviate; SHOULD NOT = discouraged.
+MAY = truly optional.
+Voice: active, imperative or declarative. One directive per line.
+Sentences: max 20 words. Paragraphs: max 6 sentences, one topic each.
+Multi-word nouns: 3 words max unless whitelisted.
+>>
+</constants>
+
+<formats>
+<format id="ERROR" name="Format Error" purpose="Emit a single-line reason when a requested format cannot be produced.">
+- Output wrapper starts with a fenced block whose info string is exactly format:ERROR.
+- Body is AG-036 FormatContractViolation: <ONE_LINE_REASON>.
+WHERE:
+- <ONE_LINE_REASON> is String.
+- <ONE_LINE_REASON> is ≤ 160 characters.
+- <ONE_LINE_REASON> contains no newlines.
+</format>
+
+<format id="ASK_V1" name="Intent + Minimal Probe" purpose="Show the current intent and ask up to 2 blocker questions with suggested answers.">
+STATE: <STATE>
+
+<intent>
+<INTENT>
+</intent>
+
+ASK
+<QUESTIONS>
+
+CTA: <CTA>
+WHERE:
+- <STATE> is String.
+- <INTENT> is String.
+- <QUESTIONS> is MultilineQuestions where each question has format:
+  Q<N>: <question_text>
+  a) <option_1>
+  b) <option_2>
+  c) <option_3>
+  d) <option_4>
+  e) All of the above / None / Other (specify)
+- <CTA> is String.
+</format>
+
+<format id="OUT_V1" name="Generated Agent + Lint Report" purpose="Confirm file written, show lint report, and offer actions if issues found.">
+# <AGENT_NAME>
+Platform: <TARGET_PLATFORM>
+File: <FILE_PATH>
+
+## Lint Report
+
+<LINT>
+
+<ACTIONS>
+WHERE:
+- <AGENT_NAME> is String.
+- <TARGET_PLATFORM> is String.
+- <FILE_PATH> is Path.
+- <LINT> is String; the lint report output.
+- <ACTIONS> is String; empty when lint passes, otherwise actionable choices:
+  "Reply **fix** to regenerate with corrections, **re-lint** to lint again, or **refactor** to start over."
+</format>
+</formats>
+
+<runtime>
+USER_INPUT: ""
+SESSION_INIT: false
+SKILL_CONTENT: ""
+TARGET_PLATFORM: ""
+PLATFORM_CONFIG: {}
+FRONTMATTER_TEMPLATE: ""
+ADAPTER_TOOLS: ""
+STATE: ""
+INTENT: ""
+QUESTIONS: ""
+INTENT_OK: false
+AGENT_SLUG: ""
+FILE_PATH: ""
+AGENT: ""
+LINT: ""
+LINT_CLEAN: false
+FIELD_REQUIREMENTS: {}
+INTENT_MODE: ""
+</runtime>
+
+<triggers>
+<trigger event="user_message" target="router" />
+</triggers>
+
+<processes>
+<process id="router" name="Route">
+IF SESSION_INIT is false:
+  RUN `init`
+IF INTENT_MODE is empty:
+  SET INTENT_MODE := <MODE> (from "Agent Inference" using USER_INPUT)
+IF INTENT_MODE = "skill":
+  RUN `load-skill-builder`
+  RETURN
+IF TARGET_PLATFORM is empty:
+  RUN `ask-platform`
+  RETURN: format="ASK_V1", cta=CTA, intent=INTENT, questions=QUESTIONS, state=STATE
+IF USER_INPUT matches "fix":
+  RUN `generate`
+  RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, target_platform=TARGET_PLATFORM, actions=ACTIONS
+IF USER_INPUT matches "re-lint":
+  SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
+  SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
+  RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, target_platform=TARGET_PLATFORM, actions=ACTIONS
+IF USER_INPUT matches "refactor":
+  SET INTENT_OK := false (from "Agent Inference")
+  RUN `refine`
+  IF INTENT_OK is false:
+    RETURN: format="ASK_V1", cta=CTA, intent=INTENT, questions=QUESTIONS, state=STATE
+  RUN `generate`
+  RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, target_platform=TARGET_PLATFORM, actions=ACTIONS
+RUN `refine`
+IF INTENT_OK is false:
+  RETURN: format="ASK_V1", cta=CTA, intent=INTENT, questions=QUESTIONS, state=STATE
+RUN `generate`
+RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, target_platform=TARGET_PLATFORM, actions=ACTIONS
+</process>
+
+<process id="init" name="Init+Load Skill">
+SET SESSION_INIT := true (from "Agent Inference")
+USE `read` where: file_path=SKILL_PATH
+CAPTURE SKILL_CONTENT from `read`
+IF SKILL_CONTENT is empty:
+  USE `read` where: file_path=SKILL_PATH_ALT
+  CAPTURE SKILL_CONTENT from `read`
+</process>
+
+<process id="ask-platform" name="Ask Target Platform">
+SET STATE := "Selecting target platform" (from "Agent Inference")
+SET INTENT := "Target platform not yet selected" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) GitHub Copilot CLI (.github/agents/*.agent.md)\n  b) VS Code Copilot (.github/agents/*.agent.md)\n  c) Claude Code (.claude/agents/*.md)\n  d) Same as current platform (GitHub Copilot CLI)\n  e) Other / Cancel" (from "Agent Inference")
+SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
+IF TARGET_PLATFORM is not empty:
+  RUN `load-platform`
+</process>
+
+<process id="load-platform" name="Load Platform Adapter">
+SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
+SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
+USE `read` where: file_path=ADAPTOR_PATH
+CAPTURE ADAPTOR_CONTENT from `read`
+IF ADAPTOR_CONTENT is empty:
+  SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
+  USE `read` where: file_path=ADAPTOR_PATH
+  CAPTURE ADAPTOR_CONTENT from `read`
+SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
+SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
+IF TARGET_PLATFORM = "claude-code":
+  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_CLAUDE (from "Constant Lookup")
+ELSE IF TARGET_PLATFORM = "vscode-copilot":
+  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_VSCODE (from "Constant Lookup")
+ELSE:
+  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_COPILOT_CLI (from "Constant Lookup")
+</process>
+
+<process id="refine" name="Intent">
+SET STATE := <STATE_TEXT> (from "Agent Inference" using USER_INPUT, TARGET_PLATFORM)
+SET INTENT := <INTENT_FACTS> (from "Agent Inference" using USER_INPUT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, TARGET_PLATFORM, FIELD_REQUIREMENTS, SECTION_GUIDE)
+SET QUESTIONS := <BLOCKERS> (from "Agent Inference" using INTENT, ASK_RULES, FIELD_REQUIREMENTS)
+SET INTENT_OK := <DONE> (from "Agent Inference")
+</process>
+
+<process id="generate" name="Generate+Write+Lint">
+IF TARGET_PLATFORM = "claude-code":
+  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_CLAUDE)
+ELSE IF TARGET_PLATFORM = "vscode-copilot":
+  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
+ELSE:
+  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_COPILOT_CLI)
+SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
+SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
+USE `shell` where: command="mkdir -p PLATFORM_CONFIG.agentsDir"
+USE `write` where: content=AGENT, file_path=FILE_PATH
+SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
+SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
+</process>
+
+<process id="load-skill-builder" name="Load Skill Builder">
+SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
+SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
+USE `read` where: file_path=BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from `read`
+SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
+USE `read` where: file_path=GUIDE_PATH
+CAPTURE GUIDE_CONTENT from `read`
+SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
+TELL "Skill builder loaded. Following build-skill process workflow." level=brief
+</process>
+</processes>
+
+<input>
+USER_INPUT is the user's latest message containing goals or answers.
+</input>

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.1.agent.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.1.agent.md
@@ -1,13 +1,15 @@
 ---
 name: APS v1.2.1 Agent
-description: "Generate APS v1.2.1 .agent.md or .md agent files for any supported platform: detect artifact type from user intent, load APS+target adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
-model: inherit
-allowed-tools:
-  - read
-  - write
-  - shell(mkdir:*)
-  - shell(ls:*)
+description: "Generate APS v1.2.1 .agent.md, .agent.yaml, or .md agent files for any supported platform: detect artifact type from user intent, load APS+target adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+tools:
+  - view
+  - create
+  - edit
+  - bash
+  - grep
+  - glob
   - web_fetch
+  - fetch_copilot_cli_documentation
 ---
 
 <instructions>
@@ -28,7 +30,7 @@ You MUST derive AGENT_SLUG deterministically from the final intent using SLUG_RU
 You MUST always write the generated agent to disk, then lint the written file, then present the lint report.
 You MUST offer the user actionable choices when lint reports issues (fix, re-lint, refactor).
 You MUST redact secrets and personal data in any logs or artifacts.
-You MUST use platform-specific syntax: YAML array of snake_case + paren-arg patterns for Copilot CLI, YAML arrays of qualified names for VS Code Copilot, comma-separated PascalCase strings for Claude Code.
+You MUST use platform-specific tool grammars: bare snake_case names plus `<server>/<tool>` for MCP in Copilot CLI agent `tools:` arrays; YAML arrays of qualified names for VS Code Copilot; comma-separated PascalCase strings for Claude Code.
 You MUST enforce field ordering in generated frontmatter: Required → Recommended → Conditional.
 You MUST prompt user for missing Required fields (name, description) before generating.
 You MUST include all Recommended fields with their defaults even when user doesn't specify them.
@@ -45,7 +47,7 @@ You MUST NOT place workflows or control flow in <instructions>; use <processes>.
 You MUST NOT place static rules in <processes>; use <instructions>.
 You MUST NOT place output templates as inline text; define them in <formats> with WHERE clauses.
 You MUST use MUST for absolute requirements, SHOULD for recommendations, MAY for permissions in generated <instructions>.
-You MUST prefer specific tool names (e.g., `shell(git:*)`) over the broad `shell` toolset; consult TOOL_SELECTION.
+You MUST prefer specific tool names from TOOL_BUILT_IN over the wildcard `"*"` in Copilot CLI agent `tools:` arrays; consult TOOL_SELECTION.
 You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
@@ -93,14 +95,35 @@ PLATFORMS: JSON<<
 
 FIELD_REQUIREMENTS_COPILOT_CLI: JSON<<
 {
-  "required": ["name", "description"],
-  "recommended": {
-    "model": "inherit",
-    "allowed-tools": []
+  "format_native_yaml": {
+    "extension": ".agent.yaml",
+    "required": ["name", "description"],
+    "recommended": {
+      "displayName": "",
+      "model": "",
+      "tools": [],
+      "promptParts": {
+        "includeAISafety": true,
+        "includeToolInstructions": true,
+        "includeParallelToolCalling": true,
+        "includeCustomAgentInstructions": false,
+        "includeEnvironmentContext": false
+      },
+      "prompt": ""
+    },
+    "fieldOrder": ["name", "displayName", "description", "model", "tools", "promptParts", "prompt"],
+    "deprecated": []
   },
-  "conditional": ["mcp-servers"],
-  "fieldOrder": ["name", "description", "model", "allowed-tools", "mcp-servers"],
-  "deprecated": []
+  "format_vscode_md": {
+    "extension": ".agent.md",
+    "required": ["name", "description"],
+    "recommended": {
+      "model": "",
+      "tools": []
+    },
+    "fieldOrder": ["name", "description", "model", "tools"],
+    "deprecated": ["allowed-tools", "user-invocable", "disable-model-invocation", "target", "mcp-servers"]
+  }
 }
 >>
 
@@ -182,16 +205,16 @@ LINT_CHECKS: TEXT<<
 - every format:<ID> referenced exists
 - output is exactly one fenced block per turn
 - frontmatter matches target platform schema
-- tools syntax matches target platform (snake_case+paren-arg vs qualified vs comma-separated)
+- tools syntax matches target platform (bare snake_case + slash MCP for Copilot CLI vs qualified for VS Code vs comma-separated PascalCase for Claude Code)
 - frontmatter field order: Required fields first, then Recommended, then Conditional
 - all Required fields (name, description) are present and non-empty
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
-- Copilot CLI: allowed-tools is YAML array of snake_case patterns; model is string; description is single-line quoted
-- Copilot CLI: VS Code-only fields (user-invocable, disable-model-invocation, target) MUST NOT appear
-- Copilot CLI: tool patterns use snake_case with optional paren-arg (shell, shell(git:*), web_fetch)
-- Copilot CLI: MCP tools follow <ServerName>(<tool_name>) pattern
+- Copilot CLI: tools is YAML array of bare snake_case names (view, create, edit, bash, web_fetch, task) or `<server>/<tool>` slash patterns for MCP; model is bare model id; description is single-line quoted
+- Copilot CLI: VS Code-only fields (user-invocable, disable-model-invocation, target, allowed-tools) MUST NOT appear in `.agent.md` frontmatter
+- Copilot CLI: do NOT use `read` or `write` as tool names — they are permission categories. Use `view` (read), `create` (new file), or `edit` (modify) instead
+- Copilot CLI: MCP tools in `tools:` arrays use `<server>/<tool>` slash; permission patterns in --allow-tool/--deny-tool use `<server>(<tool>?)` paren
 - VS Code: tools is YAML array, user-invocable is boolean, disable-model-invocation is boolean, target is string
 - VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
 - VS Code: deprecated `user-invokable` field MUST NOT appear in generated frontmatter
@@ -300,14 +323,15 @@ AG-046: BlockConstantTypeUnknown — unknown block type (valid: JSON, TEXT, YAML
 
 TOOL_SELECTION: TEXT<<
 Tool selection rules for generated agent frontmatter:
-Default to specific tool patterns; avoid the broadest `shell` allow.
-Use `shell(<command>:*)` to scope shell access to a command family (e.g., `shell(git:*)`, `shell(npm:*)`).
-Copilot CLI: snake_case + paren-arg patterns (shell, shell(git:*), read, write, web_fetch, <ServerName>(<tool_name>)).
+Default to specific tool names; avoid the wildcard `"*"` allow unless the agent genuinely needs every tool.
+Copilot CLI tool names (bare snake_case in `tools:` arrays): view, create, edit, bash (read_bash, stop_bash), powershell (read_powershell, stop_powershell, list_powershell), grep, glob, lsp, web_fetch, web_search, task, ask_user, fetch_copilot_cli_documentation, report_intent, sql, skill, read_agent, list_agents.
+Copilot CLI MCP tools in `tools:` arrays use `<server>/<tool>` slash notation (e.g., `github-mcp-server/get_pull_request`).
+Copilot CLI permission patterns (used in --allow-tool/--deny-tool, NOT in `tools:` arrays) use `kind(arg?)` form: `shell(git:*)`, `write`, `url(https://*.github.com)`, `<server>(<tool>?)`.
 Claude Code: single-tier PascalCase (Read, Bash, Glob); no qualification.
 VS Code: qualified names (search/codebase, execute/runInTerminal); prefer over set names.
 Consult ADAPTER_TOOLS recommended.aps.planner or recommended.aps.implementer for defaults.
 Trim tools the agent does not need; add tools it specifically requires.
-Read-only agents: read + web_fetch only. Implementer agents: add write + scoped shell.
+Read-only agents: view + grep + glob + web_fetch only. Implementer agents: add create, edit, and bash.
 >>
 
 VOCAB_RULES: TEXT<<
@@ -435,11 +459,11 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-USE `read` where: file_path=SKILL_PATH
-CAPTURE SKILL_CONTENT from `read`
+USE `view` where: file_path=SKILL_PATH
+CAPTURE SKILL_CONTENT from `view`
 IF SKILL_CONTENT is empty:
-  USE `read` where: file_path=SKILL_PATH_ALT
-  CAPTURE SKILL_CONTENT from `read`
+  USE `view` where: file_path=SKILL_PATH_ALT
+  CAPTURE SKILL_CONTENT from `view`
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
@@ -454,12 +478,12 @@ IF TARGET_PLATFORM is not empty:
 <process id="load-platform" name="Load Platform Adapter">
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
-USE `read` where: file_path=ADAPTOR_PATH
-CAPTURE ADAPTOR_CONTENT from `read`
+USE `view` where: file_path=ADAPTOR_PATH
+CAPTURE ADAPTOR_CONTENT from `view`
 IF ADAPTOR_CONTENT is empty:
   SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
-  USE `read` where: file_path=ADAPTOR_PATH
-  CAPTURE ADAPTOR_CONTENT from `read`
+  USE `view` where: file_path=ADAPTOR_PATH
+  CAPTURE ADAPTOR_CONTENT from `view`
 SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
 SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
 IF TARGET_PLATFORM = "claude-code":
@@ -486,8 +510,8 @@ ELSE:
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_COPILOT_CLI)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `shell` where: command="mkdir -p PLATFORM_CONFIG.agentsDir"
-USE `write` where: content=AGENT, file_path=FILE_PATH
+USE `bash` where: command="mkdir -p PLATFORM_CONFIG.agentsDir"
+USE `create` where: content=AGENT, file_path=FILE_PATH
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 </process>
@@ -495,11 +519,11 @@ SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 <process id="load-skill-builder" name="Load Skill Builder">
 SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
 SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
-USE `read` where: file_path=BUILD_PROCESS_PATH
-CAPTURE BUILD_SKILL_CONTENT from `read`
+USE `view` where: file_path=BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from `view`
 SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
-USE `read` where: file_path=GUIDE_PATH
-CAPTURE GUIDE_CONTENT from `read`
+USE `view` where: file_path=GUIDE_PATH
+CAPTURE GUIDE_CONTENT from `view`
 SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
 TELL "Skill builder loaded. Following build-skill process workflow." level=brief
 </process>


### PR DESCRIPTION
## Summary

Add a dedicated platform adapter for the **standalone GitHub Copilot CLI** (the `copilot` binary, GA 2026-02-25), distinct from the existing `vscode-copilot` adapter for the VS Code extension. Ships an `aps-v1.2.1.agent.md` template, registers the adapter in both Node and Python CLIs, and updates docs.

## Motivation

Users running APS workflows from the standalone Copilot CLI today have no canonical adapter — they have to fall back to `vscode-copilot`, which encodes VS Code-specific assumptions (three-tier qualified tool names, no hooks, no permissions config) that don't match what the CLI actually exposes. The two surfaces share install directories by design (Copilot CLI was named `~/.copilot/` to be the canonical Copilot home), but their tool grammars, permission models, and orchestration surfaces are distinct enough to require their own adapter.

| Surface | `vscode-copilot` | `copilot-cli` (new) |
|---|---|---|
| Host process | VS Code extension running inside the editor | Standalone `copilot` binary in the terminal |
| Tool grammar | three-tier `toolset/qualifiedName/functionName` | snake_case + paren-arg (`shell(git commit)`, `shell(git:*)`, `web_fetch`) |
| Subagent invocation | `agent` / `runSubagent` / handoffs (chat surface) | `/fleet [PROMPT]` slash command (CLI surface) |
| Permissions | VS Code's tool gating | `~/.copilot/permissions-config.json`, `--allow-tool` / `--deny-tool` |
| Hooks | Not documented | First-class lifecycle hooks (`hooks.json`, six events) |

A welcome side-effect: the adapter documents (per verbatim docs at `docs.github.com/.../create-skills`) that **Copilot CLI also reads `.claude/skills/` and `~/.claude/skills/`**, so a skill installed via `aps init --platform claude-code` is automatically discoverable by Copilot CLI users on the same machine. The new `CROSS_PLATFORM_INTEROP` constant makes that interop property queryable by APS-aware tooling.

## Changes

### Change Tree
```
# Legend: A = Added, M = Modified

skill/agnostic-prompt-standard/
├── platforms/
│   ├── README.md                                                # M: list shipped adapters; note vscode-copilot/copilot-cli share dirs
│   └── copilot-cli/
│       ├── adaptor.md                                           # A: single source of truth (instructions/constants/formats)
│       └── templates/.github/agents/
│           └── aps-v1.2.1.agent.md                              # A: meta-agent template (3-platform router)

README.md                                                        # M: add `--platform copilot-cli` quickstart, update tree

packages/aps-cli-node/
├── src/detection/adapters.ts                                    # M: extend KnownAdapterId + DEFAULT_ADAPTER_ORDER
└── test/detection.test.ts                                       # M: update DEFAULT_ADAPTER_ORDER registration test

packages/aps-cli-py/
├── src/aps_cli/core.py                                          # M: extend KnownAdapterId + DEFAULT_ADAPTER_ORDER
└── tests/test_core.py                                           # M: update DEFAULT_ADAPTER_ORDER registration test
```

### Details

**New adapter (`platforms/copilot-cli/adaptor.md`)**
- `<instructions>`: snake_case + paren-arg tool grammar, file location precedence (personal-wins-on-name-collision for agents), allow/deny tool patterns, hooks lifecycle, `/fleet` worker invocation surface, cross-platform interop note.
- `<constants>`: `PLATFORM_ID="copilot-cli"`, `DISPLAY_NAME="GitHub Copilot CLI"`, `ADAPTER_VERSION="1.0.0"`, `ARTIFACT_TYPES` CSV (agents/skills/instructions/hooks/mcp-config/permissions/config), `SUBAGENT_ARCHITECTURE` JSON with `depth_policy: depth-1-only`, install paths, `HOOK_EVENTS` (sessionStart, sessionEnd, userPromptSubmitted, preToolUse, postToolUse, errorOccurred), `CONFIG_HOME_ENV: COPILOT_HOME`, `TOOL_NAMING_STYLE`, built-in tool list, MCP tool pattern, `CROSS_PLATFORM_INTEROP` documenting `.claude/skills/` discoverability, doc URLs.
- `<formats>`: `COPILOT_CLI_AGENT_FRONTMATTER_V1`, `COPILOT_CLI_SKILL_FRONTMATTER_V1`, `COPILOT_CLI_INSTRUCTIONS_FRONTMATTER_V1`, `COPILOT_CLI_HOOKS_CONFIG_V1`, `COPILOT_CLI_MCP_CONFIG_V1`, `COPILOT_CLI_PERMISSIONS_V1`, `COPILOT_CLI_CONFIG_V1`.

**Agent template (`templates/.github/agents/aps-v1.2.1.agent.md`)**
- Derived from `vscode-copilot/templates/.github/agents/aps-v1.2.1.agent.md` (closest sibling — same `.agent.md` extension, same `.github/agents/` location).
- Frontmatter adapted to Copilot CLI's simpler schema: `name`, `description`, `model: inherit`, `allowed-tools` (snake_case + paren-arg patterns including scoped `shell(mkdir:*)`).
- `PLATFORMS` constant extended to include `copilot-cli` alongside `vscode-copilot` and `claude-code` so the meta-agent can target all three from any host.
- Process steps switched from VS Code's two-tool pattern (`edit/createDirectory` + `edit/createFile`) to Copilot CLI's `USE \`shell\` where: command="mkdir -p ..."` + `USE \`write\``, with explicit `USE \`read\` where: file_path=...` for skill/adapter loading.
- New `FIELD_REQUIREMENTS_COPILOT_CLI`, `SLUG_RULES_COPILOT_CLI`, and Copilot-CLI-specific lint checks added.

**CLI registry (Node + Python)**
- Extended `KnownAdapterId` Literal type and `DEFAULT_ADAPTER_ORDER` to include `'copilot-cli'`, positioned right after `'vscode-copilot'` to keep the GitHub Copilot brand grouping adjacent in `aps platforms`.
- **No install-path branching changes needed**: both CLIs use a binary `is_claude_code(platform_id)` check that already routes anything not matching `claude-code` to the `~/.copilot/skills/` family — exactly where Copilot CLI's docs say it reads from.
- **No `inferPlatformId` changes**: `copilot-cli` and `vscode-copilot` share the same workspace markers (`.github/copilot-instructions.md`, `.github/agents/`), so any heuristic would be unreliable. The user disambiguates by passing `--platform copilot-cli` explicitly.

**Registration test updates**
- Both CLIs have a `DEFAULT_ADAPTER_ORDER` deep-equality test that intentionally fails when a new adapter is added, forcing a deliberate review of the canonical order. Updated both to include `copilot-cli` in the new position. All other adapter property tests (required constants, unique format ids, `SUBAGENT_ARCHITECTURE` shape, `SUBAGENT_AUTHORING_GUIDE` presence) loop over every adapter and adopted the new one for free — no new test files needed.

## Testing

- [x] `python tools/sync_payload.py` — both payloads synced
- [x] `python tools/check_versions.py` — `OK: version=1.2.1`
- [x] `python tools/check_skill_links.py` — `OK: no broken relative links`
- [x] `npm test --prefix packages/aps-cli-node` — **60/60 passing**
- [x] `python -m pytest -q packages/aps-cli-py/tests` — **65/65 passing**
- [x] `node packages/aps-cli-node/bin/aps.js platforms` — lists `copilot-cli` v1.0.0 in slot 2 (right after `vscode-copilot`)
- [x] `python -m aps_cli platforms` — identical output
- [x] `aps init --platform copilot-cli --dry-run --yes` (Node + Python) — both plan the install at `.github/skills/agnostic-prompt-standard/` plus 1 template file at `.github/agents/aps-v1.2.1.agent.md`
- [x] `aps doctor --root <synthetic project>` (Node + Python) — both detect `copilot-cli` via `.github/copilot-instructions.md` + `.github/agents/` markers
- [ ] CI version consistency check


Closes #67
