### PR TITLE
chore: ignore scratch/ for local workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ CLAUDE.md
 # Local workspace
 issues/
 prompts/
+scratch/


### PR DESCRIPTION
## Summary

Adds `scratch/` to the `.gitignore` Local workspace block alongside existing `issues/` and `prompts/`. The directory holds personal/local-only files (research PDFs, drafts, scratch text, oracle session bundles) that should never be committed.

## Test plan

- [x] `git status --short` reports clean working tree after the change
- [x] `git check-ignore -v scratch/<file>` confirms the new rule fires on existing scratch contents