### PR TITLE
chore(ci): migrate publish workflows to OIDC Trusted Publishers (v1.2.2)

### DIFF
--- a/.github/workflows/dev-publish.yml
+++ b/.github/workflows/dev-publish.yml
@@ -1,4 +1,4 @@
-name: Dev Publish
+name: Dev Build
 
 on:
   push:
@@ -7,20 +7,22 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   dev-node:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: packages/aps-cli-node/package-lock.json
       - name: Install and test
         working-directory: packages/aps-cli-node
-        run: npm install && npm test
+        run: npm ci --ignore-scripts && npm test
       - name: Set dev version
         working-directory: packages/aps-cli-node
         run: |
@@ -34,14 +36,11 @@ jobs:
         with:
           name: npm-package
           path: packages/aps-cli-node/*.tgz
-      - name: Publish to npm (dev tag)
-        working-directory: packages/aps-cli-node
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag dev --provenance
 
   dev-python:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -70,8 +69,3 @@ jobs:
         with:
           name: python-package
           path: dist/*
-      - name: Publish to PyPI (dev)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: dist

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -7,79 +7,92 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  publish-node:
+  verify:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - run: python tools/check_versions.py --tag "${GITHUB_REF_NAME}"
+      - run: python tools/check_skill_links.py
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+  publish-node:
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
         with:
-          node-version: '22'
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: packages/aps-cli-node/package-lock.json
-
-      - name: Verify tagged version
-        run: python tools/check_versions.py --tag "${GITHUB_REF_NAME}"
-
-      - name: Sync Node payload
-        run: python tools/sync_payload.py --node
-
-      - name: Install Node CLI dependencies
-        run: npm ci --prefix packages/aps-cli-node --ignore-scripts
-
-      - name: Run Node CLI tests
-        run: npm test --prefix packages/aps-cli-node
-
-      - name: Publish Node package to npm
+      - run: python tools/sync_payload.py --node
+      - run: npm ci --prefix packages/aps-cli-node --ignore-scripts
+      - run: npm test --prefix packages/aps-cli-node
+      - name: Publish to npm via OIDC
         working-directory: packages/aps-cli-node
         run: npm publish --access public --provenance
 
   publish-python:
+    needs: verify
     runs-on: ubuntu-latest
-
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Verify tagged version
-        run: python tools/check_versions.py --tag "${GITHUB_REF_NAME}"
-
-      - name: Sync Python payload
-        run: python tools/sync_payload.py --python
-
-      - name: Install Python build + test dependencies
-        run: |
+      - run: python tools/sync_payload.py --python
+      - run: |
           python -m pip install --upgrade pip build
           python -m pip install -e "packages/aps-cli-py[dev]"
-
-      - name: Run Python CLI tests
-        run: python -m pytest -q packages/aps-cli-py/tests
-
-      - name: Build Python distributions
-        run: python -m build packages/aps-cli-py
-
-      - name: Publish Python package to PyPI
+      - run: python -m pytest -q packages/aps-cli-py/tests
+      - run: python -m build --outdir packages/aps-cli-py/dist packages/aps-cli-py
+      - name: Publish to PyPI via OIDC
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: packages/aps-cli-py/dist
+
+  github-release:
+    needs: [publish-node, publish-python]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create skill zip
+        run: |
+          mkdir -p dist
+          cd skill
+          zip -r "../dist/agnostic-prompt-standard-skill-${GITHUB_REF_NAME}.zip" agnostic-prompt-standard
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: dist/agnostic-prompt-standard-skill-${{ github.ref_name }}.zip
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,23 @@
-name: Release
+name: Create release tag
 
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
-  group: release
+  group: create-release-tag
   cancel-in-progress: false
 
 jobs:
   check_release:
-    # Only run on push to main (not on tag push)
-    if: github.ref == 'refs/heads/main'
+    if: github.actor != 'github-actions[bot]' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
       version: ${{ steps.check.outputs.version }}
@@ -32,147 +31,49 @@ jobs:
       - name: Check if release needed
         id: check
         run: |
-          # Extract version from SKILL.md
           VERSION=$(python -c "
-          import re
-          text = open('skill/agnostic-prompt-standard/SKILL.md').read()
-          m = re.search(r'framework_revision:\s*\"?([0-9]+\.[0-9]+\.[0-9]+)\"?', text)
-          print(m.group(1))
+          import re, pathlib
+          text = pathlib.Path('skill/agnostic-prompt-standard/SKILL.md').read_text()
+          print(re.search(r'framework_revision:\s*\"?([0-9]+\.[0-9]+\.[0-9]+)\"?', text).group(1))
           ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          # Check if tag exists
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
             echo "Tag v$VERSION already exists, skipping release"
             echo "should_release=false" >> $GITHUB_OUTPUT
           else
-            echo "Tag v$VERSION does not exist, will release"
+            echo "Tag v$VERSION does not exist, will create it"
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
   verify:
     needs: check_release
-    if: |
-      always() &&
-      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Version consistency
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            python tools/check_versions.py --tag "${{ github.ref_name }}"
-          else
-            python tools/check_versions.py
-          fi
-      - name: Skill link integrity
-        run: python tools/check_skill_links.py
-
-  publish_node:
-    needs: [check_release, verify]
-    if: |
-      always() &&
-      needs.verify.result == 'success' &&
-      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install deps
-        working-directory: packages/aps-cli-node
-        run: npm install
-      - name: Test
-        working-directory: packages/aps-cli-node
-        run: npm test
-      - name: Publish to npm (token)
-        if: env.NPM_TOKEN != ''
-        working-directory: packages/aps-cli-node
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-        run: npm publish --access public --provenance
-      - name: Publish to npm (trusted publishing / OIDC)
-        if: env.NPM_TOKEN == ''
-        working-directory: packages/aps-cli-node
-        run: npm publish --access public
-
-  publish_python:
-    needs: [check_release, verify]
-    if: |
-      always() &&
-      needs.verify.result == 'success' &&
-      (needs.check_release.outputs.should_release == 'true' || startsWith(github.ref, 'refs/tags/'))
-    runs-on: ubuntu-latest
-    env:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Build distributions
-        run: |
-          python -m pip install -U pip build
-          python tools/sync_payload.py --python
-          python -m build --outdir packages/aps-cli-py/dist packages/aps-cli-py
-      - name: Publish to PyPI (token)
-        if: env.PYPI_API_TOKEN != ''
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ env.PYPI_API_TOKEN }}
-          packages-dir: packages/aps-cli-py/dist
-      - name: Publish to PyPI (trusted publishing / OIDC)
-        if: env.PYPI_API_TOKEN == ''
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: packages/aps-cli-py/dist
-
-  create_tag_and_release:
-    needs: [check_release, publish_node, publish_python]
     if: needs.check_release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python tools/check_versions.py
+      - run: python tools/check_skill_links.py
+
+  create_tag:
+    needs: [check_release, verify]
+    if: needs.check_release.outputs.should_release == 'true' && needs.verify.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Create and push tag
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "v${{ needs.check_release.outputs.version }}"
           git push origin "v${{ needs.check_release.outputs.version }}"
-      - name: Create skill zip
-        run: |
-          mkdir -p dist
-          cd skill
-          zip -r "../dist/agnostic-prompt-standard-skill-v${{ needs.check_release.outputs.version }}.zip" agnostic-prompt-standard
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.check_release.outputs.version }}
-          files: dist/agnostic-prompt-standard-skill-v${{ needs.check_release.outputs.version }}.zip
-          generate_release_notes: true
-
-  github_release:
-    # Only for manual tag-based releases
-    needs: [publish_node, publish_python]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Create skill zip
-        run: |
-          mkdir -p dist
-          cd skill
-          zip -r "../dist/agnostic-prompt-standard-skill-${{ github.ref_name }}.zip" agnostic-prompt-standard
-      - name: Create GitHub Release (attach skill zip)
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/agnostic-prompt-standard-skill-${{ github.ref_name }}.zip

--- a/packages/aps-cli-node/package-lock.json
+++ b/packages/aps-cli-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agnostic-prompt/aps",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/packages/aps-cli-node/package.json
+++ b/packages/aps-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agnostic-prompt/aps",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates.",
   "type": "module",
   "bin": {

--- a/packages/aps-cli-py/pyproject.toml
+++ b/packages/aps-cli-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agnostic-prompt-aps"
-version = "1.2.1"
+version = "1.2.2"
 description = "CLI to install and manage the Agnostic Prompt Standard (APS) skill and platform templates."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/aps-cli-py/src/aps_cli/__init__.py
+++ b/packages/aps-cli-py/src/aps_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/skill/agnostic-prompt-standard/SKILL.md
+++ b/skill/agnostic-prompt-standard/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: "Christopher Buckley"
   co_authors: "Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
-  framework_revision: "1.2.1"
+  framework_revision: "1.2.2"
   last_updated: "2026-03-12"
 ---
 

--- a/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/claude-code/adaptor.md
@@ -117,7 +117,7 @@ AGENT_VERSIONING: JSON<<
   "templates": [
     {
       "path": "templates/.claude/agents/aps-v{major}.{minor}.{patch}.md",
-      "current_path": "templates/.claude/agents/aps-v1.2.1.md",
+      "current_path": "templates/.claude/agents/aps-v1.2.2.md",
       "frontmatter": {
         "name_pattern": "aps-v{major}-{minor}-{patch}",
         "description_pattern": "Generate APS v{major}.{minor}.{patch} agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint."

--- a/skill/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.2.2.md
+++ b/skill/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.2.2.md
@@ -1,6 +1,6 @@
 ---
-name: aps-v1-2-1
-description: "Generate APS v1.2.1 agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+name: aps-v1-2-2
+description: "Generate APS v1.2.2 agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
 model: inherit
 tools: Read, Write, Glob, Grep, Bash, TodoWrite
 disallowedTools: Edit, MultiEdit

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/adaptor.md
@@ -261,7 +261,7 @@ AGENT_VERSIONING: JSON<<
   "templates": [
     {
       "path": "templates/.github/agents/aps-v{major}.{minor}.{patch}.agent.md",
-      "current_path": "templates/.github/agents/aps-v1.2.1.agent.md",
+      "current_path": "templates/.github/agents/aps-v1.2.2.agent.md",
       "frontmatter": {
         "name_pattern": "APS v{major}.{minor}.{patch} Agent",
         "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md or .agent.yaml files for the Copilot CLI: detect artifact type from user intent, load APS+Copilot CLI adapter, extract intent, then generate+write+lint."

--- a/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.2.agent.md
+++ b/skill/agnostic-prompt-standard/platforms/copilot-cli/templates/.github/agents/aps-v1.2.2.agent.md
@@ -1,17 +1,15 @@
 ---
-name: APS v1.2.1 Agent
-description: "Generate APS v1.2.1 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+name: APS v1.2.2 Agent
+description: "Generate APS v1.2.2 .agent.md or .agent.yaml files for the Copilot CLI: detect artifact type from user intent, load APS+Copilot CLI adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
 tools:
-  - execute/runInTerminal
-  - read/readFile
-  - edit/createDirectory
-  - edit/createFile
-  - edit/editFiles
-  - web/fetch
-  - todo
-user-invocable: true
-disable-model-invocation: true
-target: vscode
+  - view
+  - create
+  - edit
+  - bash
+  - grep
+  - glob
+  - web_fetch
+  - fetch_copilot_cli_documentation
 ---
 
 <instructions>
@@ -32,7 +30,7 @@ You MUST derive AGENT_SLUG deterministically from the final intent using SLUG_RU
 You MUST always write the generated agent to disk, then lint the written file, then present the lint report.
 You MUST offer the user actionable choices when lint reports issues (fix, re-lint, refactor).
 You MUST redact secrets and personal data in any logs or artifacts.
-You MUST use platform-specific syntax: YAML arrays for VS Code, comma-separated strings for Claude Code.
+You MUST use platform-specific tool grammars: bare snake_case names plus `<server>/<tool>` for MCP in Copilot CLI agent `tools:` arrays; YAML arrays of qualified names for VS Code Copilot; comma-separated PascalCase strings for Claude Code.
 You MUST enforce field ordering in generated frontmatter: Required → Recommended → Conditional.
 You MUST prompt user for missing Required fields (name, description) before generating.
 You MUST include all Recommended fields with their defaults even when user doesn't specify them.
@@ -49,7 +47,7 @@ You MUST NOT place workflows or control flow in <instructions>; use <processes>.
 You MUST NOT place static rules in <processes>; use <instructions>.
 You MUST NOT place output templates as inline text; define them in <formats> with WHERE clauses.
 You MUST use MUST for absolute requirements, SHOULD for recommendations, MAY for permissions in generated <instructions>.
-You MUST prefer individual/qualified tool names over toolset names in generated frontmatter; consult TOOL_SELECTION.
+You MUST prefer specific tool names from TOOL_BUILT_IN over the wildcard `"*"` in Copilot CLI agent `tools:` arrays; consult TOOL_SELECTION.
 You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
@@ -71,12 +69,19 @@ CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
 PLATFORMS: JSON<<
 {
+  "copilot-cli": {
+    "displayName": "GitHub Copilot CLI",
+    "adaptorPath": "copilot-cli/adaptor.md",
+    "agentsDir": ".github/agents/",
+    "agentExt": ".agent.md",
+    "toolSyntax": "yaml-array-snake-case"
+  },
   "vscode-copilot": {
     "displayName": "VS Code Copilot",
     "adaptorPath": "vscode-copilot/adaptor.md",
     "agentsDir": ".github/agents/",
     "agentExt": ".agent.md",
-    "toolSyntax": "yaml-array"
+    "toolSyntax": "yaml-array-qualified"
   },
   "claude-code": {
     "displayName": "Claude Code",
@@ -84,6 +89,40 @@ PLATFORMS: JSON<<
     "agentsDir": ".claude/agents/",
     "agentExt": ".md",
     "toolSyntax": "comma-separated"
+  }
+}
+>>
+
+FIELD_REQUIREMENTS_COPILOT_CLI: JSON<<
+{
+  "format_native_yaml": {
+    "extension": ".agent.yaml",
+    "required": ["name", "description"],
+    "recommended": {
+      "displayName": "",
+      "model": "",
+      "tools": [],
+      "promptParts": {
+        "includeAISafety": true,
+        "includeToolInstructions": true,
+        "includeParallelToolCalling": true,
+        "includeCustomAgentInstructions": false,
+        "includeEnvironmentContext": false
+      },
+      "prompt": ""
+    },
+    "fieldOrder": ["name", "displayName", "description", "model", "tools", "promptParts", "prompt"],
+    "deprecated": []
+  },
+  "format_vscode_md": {
+    "extension": ".agent.md",
+    "required": ["name", "description"],
+    "recommended": {
+      "model": "",
+      "tools": []
+    },
+    "fieldOrder": ["name", "description", "model", "tools"],
+    "deprecated": ["allowed-tools", "user-invocable", "disable-model-invocation", "target", "mcp-servers"]
   }
 }
 >>
@@ -114,6 +153,14 @@ FIELD_REQUIREMENTS_CLAUDE: JSON<<
   "conditional": ["disallowedTools", "skills", "hooks"],
   "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
 }
+>>
+
+SLUG_RULES_COPILOT_CLI: TEXT<<
+- lowercase ascii
+- space/\_ -> -
+- keep [a-z0-9-]
+- collapse/trim -
+- filename ends with .agent.md
 >>
 
 SLUG_RULES_VSCODE: TEXT<<
@@ -158,19 +205,23 @@ LINT_CHECKS: TEXT<<
 - every format:<ID> referenced exists
 - output is exactly one fenced block per turn
 - frontmatter matches target platform schema
-- tools syntax matches target platform (YAML array vs comma-separated)
+- tools syntax matches target platform (bare snake_case + slash MCP for Copilot CLI vs qualified for VS Code vs comma-separated PascalCase for Claude Code)
 - frontmatter field order: Required fields first, then Recommended, then Conditional
 - all Required fields (name, description) are present and non-empty
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
+- Copilot CLI: tools is YAML array of bare snake_case names (view, create, edit, bash, web_fetch, task) or `<server>/<tool>` slash patterns for MCP; model is bare model id; description is single-line quoted
+- Copilot CLI: VS Code-only fields (user-invocable, disable-model-invocation, target, allowed-tools) MUST NOT appear in `.agent.md` frontmatter
+- Copilot CLI: do NOT use `read` or `write` as tool names — they are permission categories. Use `view` (read), `create` (new file), or `edit` (modify) instead
+- Copilot CLI: MCP tools in `tools:` arrays use `<server>/<tool>` slash; permission patterns in --allow-tool/--deny-tool use `<server>(<tool>?)` paren
 - VS Code: tools is YAML array, user-invocable is boolean, disable-model-invocation is boolean, target is string
 - VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
 - VS Code: deprecated `user-invokable` field MUST NOT appear in generated frontmatter
 - Claude Code: tools is comma-separated string, model is string, permissionMode is string
 - generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
 - generated <instructions> has one directive per line with no blank lines
-- generated frontmatter tools use individual/qualified names unless all set tools needed
+- generated frontmatter tools use specific patterns unless broad set is genuinely needed
 - generated content follows SECTION_GUIDE placement (no workflows in instructions, no static rules in processes)
 - generated <constants> use YAML blocks for structured data unless JSON is the target format
 >>
@@ -272,13 +323,15 @@ AG-046: BlockConstantTypeUnknown — unknown block type (valid: JSON, TEXT, YAML
 
 TOOL_SELECTION: TEXT<<
 Tool selection rules for generated agent frontmatter:
-Default to individual/qualified tool names; avoid toolset names.
-Use a toolset ONLY when ALL tools in that set are genuinely needed.
+Default to specific tool names; avoid the wildcard `"*"` allow unless the agent genuinely needs every tool.
+Copilot CLI tool names (bare snake_case in `tools:` arrays): view, create, edit, bash (read_bash, stop_bash), powershell (read_powershell, stop_powershell, list_powershell), grep, glob, lsp, web_fetch, web_search, task, ask_user, fetch_copilot_cli_documentation, report_intent, sql, skill, read_agent, list_agents.
+Copilot CLI MCP tools in `tools:` arrays use `<server>/<tool>` slash notation (e.g., `github-mcp-server/get_pull_request`).
+Copilot CLI permission patterns (used in --allow-tool/--deny-tool, NOT in `tools:` arrays) use `kind(arg?)` form: `shell(git:*)`, `write`, `url(https://*.github.com)`, `<server>(<tool>?)`.
 Claude Code: single-tier PascalCase (Read, Bash, Glob); no qualification.
 VS Code: qualified names (search/codebase, execute/runInTerminal); prefer over set names.
 Consult ADAPTER_TOOLS recommended.aps.planner or recommended.aps.implementer for defaults.
 Trim tools the agent does not need; add tools it specifically requires.
-Read-only agents: search + read tools only. Implementer agents: add edit + execute.
+Read-only agents: view + grep + glob + web_fetch only. Implementer agents: add create, edit, and bash.
 >>
 
 VOCAB_RULES: TEXT<<
@@ -406,14 +459,17 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-READ file at SKILL_PATH or SKILL_PATH_ALT
-CAPTURE SKILL_CONTENT from read result
+USE `view` where: file_path=SKILL_PATH
+CAPTURE SKILL_CONTENT from `view`
+IF SKILL_CONTENT is empty:
+  USE `view` where: file_path=SKILL_PATH_ALT
+  CAPTURE SKILL_CONTENT from `view`
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
 SET STATE := "Selecting target platform" (from "Agent Inference")
 SET INTENT := "Target platform not yet selected" (from "Agent Inference")
-SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (VS Code Copilot)\n  e) None / Cancel" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) GitHub Copilot CLI (.github/agents/*.agent.md)\n  b) VS Code Copilot (.github/agents/*.agent.md)\n  c) Claude Code (.claude/agents/*.md)\n  d) Same as current platform (GitHub Copilot CLI)\n  e) Other / Cancel" (from "Agent Inference")
 SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
 IF TARGET_PLATFORM is not empty:
   RUN `load-platform`
@@ -422,14 +478,20 @@ IF TARGET_PLATFORM is not empty:
 <process id="load-platform" name="Load Platform Adapter">
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
-READ file at ADAPTOR_PATH (fallback to PLATFORMS_BASE_ALT if not found)
-CAPTURE ADAPTOR_CONTENT from read result
+USE `view` where: file_path=ADAPTOR_PATH
+CAPTURE ADAPTOR_CONTENT from `view`
+IF ADAPTOR_CONTENT is empty:
+  SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
+  USE `view` where: file_path=ADAPTOR_PATH
+  CAPTURE ADAPTOR_CONTENT from `view`
 SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
 SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
 IF TARGET_PLATFORM = "claude-code":
   SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_CLAUDE (from "Constant Lookup")
-ELSE:
+ELSE IF TARGET_PLATFORM = "vscode-copilot":
   SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_VSCODE (from "Constant Lookup")
+ELSE:
+  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_COPILOT_CLI (from "Constant Lookup")
 </process>
 
 <process id="refine" name="Intent">
@@ -442,12 +504,14 @@ SET INTENT_OK := <DONE> (from "Agent Inference")
 <process id="generate" name="Generate+Write+Lint">
 IF TARGET_PLATFORM = "claude-code":
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_CLAUDE)
-ELSE:
+ELSE IF TARGET_PLATFORM = "vscode-copilot":
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
+ELSE:
+  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_COPILOT_CLI)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `edit/createDirectory` where: dirPath=PLATFORM_CONFIG.agentsDir
-USE `edit/createFile` where: filePath=FILE_PATH, content=AGENT
+USE `bash` where: command="mkdir -p PLATFORM_CONFIG.agentsDir"
+USE `create` where: content=AGENT, file_path=FILE_PATH
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 </process>
@@ -455,11 +519,11 @@ SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 <process id="load-skill-builder" name="Load Skill Builder">
 SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
 SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
-READ file at BUILD_PROCESS_PATH
-CAPTURE BUILD_SKILL_CONTENT from read result
+USE `view` where: file_path=BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from `view`
 SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
-READ file at GUIDE_PATH
-CAPTURE GUIDE_CONTENT from read result
+USE `view` where: file_path=GUIDE_PATH
+CAPTURE GUIDE_CONTENT from `view`
 SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
 TELL "Skill builder loaded. Following build-skill process workflow." level=brief
 </process>

--- a/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
+++ b/skill/agnostic-prompt-standard/platforms/vscode-copilot/adaptor.md
@@ -124,7 +124,7 @@ AGENT_VERSIONING: JSON<<
   "templates": [
     {
       "path": "templates/.github/agents/aps-v{major}.{minor}.{patch}.agent.md",
-      "current_path": "templates/.github/agents/aps-v1.2.1.agent.md",
+      "current_path": "templates/.github/agents/aps-v1.2.2.agent.md",
       "frontmatter": {
         "name_pattern": "APS v{major}.{minor}.{patch} Agent",
         "description_pattern": "Generate APS v{major}.{minor}.{patch} .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint."

--- a/skill/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.2.2.agent.md
+++ b/skill/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.2.2.agent.md
@@ -1,15 +1,17 @@
 ---
-name: APS v1.2.1 Agent
-description: "Generate APS v1.2.1 .agent.md, .agent.yaml, or .md agent files for any supported platform: detect artifact type from user intent, load APS+target adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+name: APS v1.2.2 Agent
+description: "Generate APS v1.2.2 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
 tools:
-  - view
-  - create
-  - edit
-  - bash
-  - grep
-  - glob
-  - web_fetch
-  - fetch_copilot_cli_documentation
+  - execute/runInTerminal
+  - read/readFile
+  - edit/createDirectory
+  - edit/createFile
+  - edit/editFiles
+  - web/fetch
+  - todo
+user-invocable: true
+disable-model-invocation: true
+target: vscode
 ---
 
 <instructions>
@@ -30,7 +32,7 @@ You MUST derive AGENT_SLUG deterministically from the final intent using SLUG_RU
 You MUST always write the generated agent to disk, then lint the written file, then present the lint report.
 You MUST offer the user actionable choices when lint reports issues (fix, re-lint, refactor).
 You MUST redact secrets and personal data in any logs or artifacts.
-You MUST use platform-specific tool grammars: bare snake_case names plus `<server>/<tool>` for MCP in Copilot CLI agent `tools:` arrays; YAML arrays of qualified names for VS Code Copilot; comma-separated PascalCase strings for Claude Code.
+You MUST use platform-specific syntax: YAML arrays for VS Code, comma-separated strings for Claude Code.
 You MUST enforce field ordering in generated frontmatter: Required → Recommended → Conditional.
 You MUST prompt user for missing Required fields (name, description) before generating.
 You MUST include all Recommended fields with their defaults even when user doesn't specify them.
@@ -47,7 +49,7 @@ You MUST NOT place workflows or control flow in <instructions>; use <processes>.
 You MUST NOT place static rules in <processes>; use <instructions>.
 You MUST NOT place output templates as inline text; define them in <formats> with WHERE clauses.
 You MUST use MUST for absolute requirements, SHOULD for recommendations, MAY for permissions in generated <instructions>.
-You MUST prefer specific tool names from TOOL_BUILT_IN over the wildcard `"*"` in Copilot CLI agent `tools:` arrays; consult TOOL_SELECTION.
+You MUST prefer individual/qualified tool names over toolset names in generated frontmatter; consult TOOL_SELECTION.
 You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
@@ -69,19 +71,12 @@ CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
 PLATFORMS: JSON<<
 {
-  "copilot-cli": {
-    "displayName": "GitHub Copilot CLI",
-    "adaptorPath": "copilot-cli/adaptor.md",
-    "agentsDir": ".github/agents/",
-    "agentExt": ".agent.md",
-    "toolSyntax": "yaml-array-snake-case"
-  },
   "vscode-copilot": {
     "displayName": "VS Code Copilot",
     "adaptorPath": "vscode-copilot/adaptor.md",
     "agentsDir": ".github/agents/",
     "agentExt": ".agent.md",
-    "toolSyntax": "yaml-array-qualified"
+    "toolSyntax": "yaml-array"
   },
   "claude-code": {
     "displayName": "Claude Code",
@@ -89,40 +84,6 @@ PLATFORMS: JSON<<
     "agentsDir": ".claude/agents/",
     "agentExt": ".md",
     "toolSyntax": "comma-separated"
-  }
-}
->>
-
-FIELD_REQUIREMENTS_COPILOT_CLI: JSON<<
-{
-  "format_native_yaml": {
-    "extension": ".agent.yaml",
-    "required": ["name", "description"],
-    "recommended": {
-      "displayName": "",
-      "model": "",
-      "tools": [],
-      "promptParts": {
-        "includeAISafety": true,
-        "includeToolInstructions": true,
-        "includeParallelToolCalling": true,
-        "includeCustomAgentInstructions": false,
-        "includeEnvironmentContext": false
-      },
-      "prompt": ""
-    },
-    "fieldOrder": ["name", "displayName", "description", "model", "tools", "promptParts", "prompt"],
-    "deprecated": []
-  },
-  "format_vscode_md": {
-    "extension": ".agent.md",
-    "required": ["name", "description"],
-    "recommended": {
-      "model": "",
-      "tools": []
-    },
-    "fieldOrder": ["name", "description", "model", "tools"],
-    "deprecated": ["allowed-tools", "user-invocable", "disable-model-invocation", "target", "mcp-servers"]
   }
 }
 >>
@@ -153,14 +114,6 @@ FIELD_REQUIREMENTS_CLAUDE: JSON<<
   "conditional": ["disallowedTools", "skills", "hooks"],
   "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
 }
->>
-
-SLUG_RULES_COPILOT_CLI: TEXT<<
-- lowercase ascii
-- space/\_ -> -
-- keep [a-z0-9-]
-- collapse/trim -
-- filename ends with .agent.md
 >>
 
 SLUG_RULES_VSCODE: TEXT<<
@@ -205,23 +158,19 @@ LINT_CHECKS: TEXT<<
 - every format:<ID> referenced exists
 - output is exactly one fenced block per turn
 - frontmatter matches target platform schema
-- tools syntax matches target platform (bare snake_case + slash MCP for Copilot CLI vs qualified for VS Code vs comma-separated PascalCase for Claude Code)
+- tools syntax matches target platform (YAML array vs comma-separated)
 - frontmatter field order: Required fields first, then Recommended, then Conditional
 - all Required fields (name, description) are present and non-empty
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
-- Copilot CLI: tools is YAML array of bare snake_case names (view, create, edit, bash, web_fetch, task) or `<server>/<tool>` slash patterns for MCP; model is bare model id; description is single-line quoted
-- Copilot CLI: VS Code-only fields (user-invocable, disable-model-invocation, target, allowed-tools) MUST NOT appear in `.agent.md` frontmatter
-- Copilot CLI: do NOT use `read` or `write` as tool names — they are permission categories. Use `view` (read), `create` (new file), or `edit` (modify) instead
-- Copilot CLI: MCP tools in `tools:` arrays use `<server>/<tool>` slash; permission patterns in --allow-tool/--deny-tool use `<server>(<tool>?)` paren
 - VS Code: tools is YAML array, user-invocable is boolean, disable-model-invocation is boolean, target is string
 - VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
 - VS Code: deprecated `user-invokable` field MUST NOT appear in generated frontmatter
 - Claude Code: tools is comma-separated string, model is string, permissionMode is string
 - generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
 - generated <instructions> has one directive per line with no blank lines
-- generated frontmatter tools use specific patterns unless broad set is genuinely needed
+- generated frontmatter tools use individual/qualified names unless all set tools needed
 - generated content follows SECTION_GUIDE placement (no workflows in instructions, no static rules in processes)
 - generated <constants> use YAML blocks for structured data unless JSON is the target format
 >>
@@ -323,15 +272,13 @@ AG-046: BlockConstantTypeUnknown — unknown block type (valid: JSON, TEXT, YAML
 
 TOOL_SELECTION: TEXT<<
 Tool selection rules for generated agent frontmatter:
-Default to specific tool names; avoid the wildcard `"*"` allow unless the agent genuinely needs every tool.
-Copilot CLI tool names (bare snake_case in `tools:` arrays): view, create, edit, bash (read_bash, stop_bash), powershell (read_powershell, stop_powershell, list_powershell), grep, glob, lsp, web_fetch, web_search, task, ask_user, fetch_copilot_cli_documentation, report_intent, sql, skill, read_agent, list_agents.
-Copilot CLI MCP tools in `tools:` arrays use `<server>/<tool>` slash notation (e.g., `github-mcp-server/get_pull_request`).
-Copilot CLI permission patterns (used in --allow-tool/--deny-tool, NOT in `tools:` arrays) use `kind(arg?)` form: `shell(git:*)`, `write`, `url(https://*.github.com)`, `<server>(<tool>?)`.
+Default to individual/qualified tool names; avoid toolset names.
+Use a toolset ONLY when ALL tools in that set are genuinely needed.
 Claude Code: single-tier PascalCase (Read, Bash, Glob); no qualification.
 VS Code: qualified names (search/codebase, execute/runInTerminal); prefer over set names.
 Consult ADAPTER_TOOLS recommended.aps.planner or recommended.aps.implementer for defaults.
 Trim tools the agent does not need; add tools it specifically requires.
-Read-only agents: view + grep + glob + web_fetch only. Implementer agents: add create, edit, and bash.
+Read-only agents: search + read tools only. Implementer agents: add edit + execute.
 >>
 
 VOCAB_RULES: TEXT<<
@@ -459,17 +406,14 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-USE `view` where: file_path=SKILL_PATH
-CAPTURE SKILL_CONTENT from `view`
-IF SKILL_CONTENT is empty:
-  USE `view` where: file_path=SKILL_PATH_ALT
-  CAPTURE SKILL_CONTENT from `view`
+READ file at SKILL_PATH or SKILL_PATH_ALT
+CAPTURE SKILL_CONTENT from read result
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
 SET STATE := "Selecting target platform" (from "Agent Inference")
 SET INTENT := "Target platform not yet selected" (from "Agent Inference")
-SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) GitHub Copilot CLI (.github/agents/*.agent.md)\n  b) VS Code Copilot (.github/agents/*.agent.md)\n  c) Claude Code (.claude/agents/*.md)\n  d) Same as current platform (GitHub Copilot CLI)\n  e) Other / Cancel" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (VS Code Copilot)\n  e) None / Cancel" (from "Agent Inference")
 SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
 IF TARGET_PLATFORM is not empty:
   RUN `load-platform`
@@ -478,20 +422,14 @@ IF TARGET_PLATFORM is not empty:
 <process id="load-platform" name="Load Platform Adapter">
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.adaptorPath)
-USE `view` where: file_path=ADAPTOR_PATH
-CAPTURE ADAPTOR_CONTENT from `view`
-IF ADAPTOR_CONTENT is empty:
-  SET ADAPTOR_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.adaptorPath)
-  USE `view` where: file_path=ADAPTOR_PATH
-  CAPTURE ADAPTOR_CONTENT from `view`
+READ file at ADAPTOR_PATH (fallback to PLATFORMS_BASE_ALT if not found)
+CAPTURE ADAPTOR_CONTENT from read result
 SET FRONTMATTER_TEMPLATE := <FORMATS_SECTION> (from "Agent Inference" using ADAPTOR_CONTENT)
 SET ADAPTER_TOOLS := <TOOLS_CONSTANT> (from "Agent Inference" using ADAPTOR_CONTENT)
 IF TARGET_PLATFORM = "claude-code":
   SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_CLAUDE (from "Constant Lookup")
-ELSE IF TARGET_PLATFORM = "vscode-copilot":
-  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_VSCODE (from "Constant Lookup")
 ELSE:
-  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_COPILOT_CLI (from "Constant Lookup")
+  SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_VSCODE (from "Constant Lookup")
 </process>
 
 <process id="refine" name="Intent">
@@ -504,14 +442,12 @@ SET INTENT_OK := <DONE> (from "Agent Inference")
 <process id="generate" name="Generate+Write+Lint">
 IF TARGET_PLATFORM = "claude-code":
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_CLAUDE)
-ELSE IF TARGET_PLATFORM = "vscode-copilot":
-  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
 ELSE:
-  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_COPILOT_CLI)
+  SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `bash` where: command="mkdir -p PLATFORM_CONFIG.agentsDir"
-USE `create` where: content=AGENT, file_path=FILE_PATH
+USE `edit/createDirectory` where: dirPath=PLATFORM_CONFIG.agentsDir
+USE `edit/createFile` where: filePath=FILE_PATH, content=AGENT
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 </process>
@@ -519,11 +455,11 @@ SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 <process id="load-skill-builder" name="Load Skill Builder">
 SET SKILL_BASE := <BASE_DIR> (from "Agent Inference" using SKILL_PATH)
 SET BUILD_PROCESS_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.build_process)
-USE `view` where: file_path=BUILD_PROCESS_PATH
-CAPTURE BUILD_SKILL_CONTENT from `view`
+READ file at BUILD_PROCESS_PATH
+CAPTURE BUILD_SKILL_CONTENT from read result
 SET GUIDE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.guide)
-USE `view` where: file_path=GUIDE_PATH
-CAPTURE GUIDE_CONTENT from `view`
+READ file at GUIDE_PATH
+CAPTURE GUIDE_CONTENT from read result
 SET TEMPLATE_PATH := <PATH> (from "Agent Inference" using SKILL_BASE, SKILL_AUTHORING.template)
 TELL "Skill builder loaded. Following build-skill process workflow." level=brief
 </process>


### PR DESCRIPTION
## Summary

Eliminates long-lived `NPM_TOKEN` / `PYPI_API_TOKEN` by binding publish authority to the GitHub Actions OIDC identity via Trusted Publishers (configured on both registries earlier in this session).

Includes the v1.2.2 version bump that auto-bump-version.yml had drafted on `chore/auto-bump-1.2.2` (cherry-picked here so it lands together with the workflow changes — the stale auto-bump branch was dropped because its `.gitignore` base predated #68's `scratch/` rule).

## Workflow inversions

| File | New role | Trigger |
|---|---|---|
| `release.yml` | Main-only **tagger** (no publishing) | `push: branches: [main]` + `workflow_dispatch` |
| `publish-packages.yml` | **Sole** tag-driven OIDC publisher (npm + PyPI + GH Release) | `push: tags: ['v*.*.*']` |
| `dev-publish.yml` | Build + artifact upload **only** (renamed display name to "Dev Build") | `push: branches-ignore: [main]` + `workflow_dispatch` |

The `release.yml` -> tag-push -> `publish-packages.yml` chain replaces the dual-fire pattern that previously had both workflows attempting to publish on every tag.

## Why dev publishing got dropped entirely

- npm enforces **one Trusted Publisher per package** (verified empirically via UI; no `npm trusted-publishers` CLI exists)
- dev publishes permanently tombstone version numbers on both registries
- downstream consumers can `gh run download` the `.tgz` / wheel artifacts from the workflow run for PR testing
- `ci.yml` already covers test execution on PRs — `dev-publish.yml` becomes a pure build artifact source

## Pre-merge configuration done

| | |
|---|---|
| npm Trusted Publisher | `chris-buckley/agnostic-prompt-standard` / `publish-packages.yml` / env `npm` |
| PyPI Trusted Publisher | `chris-buckley/agnostic-prompt-standard` / `publish-packages.yml` / env `pypi` |
| GitHub environments | `npm`, `pypi` (active); `npm-dev`, `pypi-dev` (orphaned, will be cleaned later) |
| 2FA | Set up on `chrisbucko` (npm, WebAuthn / Windows Hello) and `bytelinkchris` (PyPI) |
| Required check | `APS CI / validate` only (matches actual workflow output names) |

## Test plan

- [x] All three workflow YAMLs parse with `yaml.safe_load`
- [x] `python tools/check_versions.py` reports `OK: version=1.2.2`
- [x] `python tools/check_skill_links.py` reports `OK: no broken relative links`
- [ ] Merge triggers `release.yml` -> creates tag `v1.2.2` -> fires `publish-packages.yml`
- [ ] OIDC npm publish succeeds; provenance attestation visible on `npm view @agnostic-prompt/aps@1.2.2`
- [ ] OIDC PyPI publish succeeds; `pip index versions agnostic-prompt-aps` shows 1.2.2
- [ ] GitHub Release created with skill zip attached
- [ ] After successful publish, `NPM_TOKEN` + `PYPI_API_TOKEN` secrets get deleted (separate commit/cleanup)